### PR TITLE
[WIP] Fix feature dependency issues on app page

### DIFF
--- a/src/js/Content/Features/Store/App/CApp.js
+++ b/src/js/Content/Features/Store/App/CApp.js
@@ -119,6 +119,10 @@ export class CApp extends CStore {
 
         FMediaExpander.dependencies = [FYouTubeVideos];
         FMediaExpander.weakDependency = true;
+
+        // FPackBreakdown skips purchase options with a package info button to avoid false positives
+        FPackageInfoButton.dependencies = [FPackBreakdown];
+        FPackageInfoButton.weakDependency = true;
     }
 
     storePageDataPromise() {


### PR DESCRIPTION
What's the difference between declaring a dependency and simply changing the order in the features array? Seems like the features are loaded in reverse order. I'm asking because there're other related issues and I'm not sure what's the best way to fix them:

~~1. `FPackBreakdown` skips purchase options with a package info button to avoid false positives, so it has to load before `FPackageInfoButton`. This is fixed by declaring a dependency in 3435c27.~~ split out
2. Currently the order of info shown by `FSteamChart`, `FSteamSpy` and `FSurveyData` is different than it was before 2.0, and it's because `FSurveyData` is loaded first. These features are added at the `beforebegin` position, so the first one will be at the top. They should be loaded in this order: `FSteamChart` -> `FSteamSpy` -> `FSurveyData` to maintain their old positions.
3. Features that anchor on to `game_details` in the right column: `FOpenCritic`, `FWidescreenCertification` and `FHowLongToBeat` also appear different than before 2.0. They're added at the "afterend" position, which means the first one will be at the bottom. The order should be: `FOpenCritic` -> `FWidescreenCertification` -> `FHowLongToBeat` to maintain their old positions.
~~4. `FOwnedElsewhere` adds a div with the `game_area_already_owned` class to the page, but our `isOwned()` method checks for this, which means features loaded after `FOwnedElsewhere` that rely on this check won't work as expected. I don't think this breaks anything at the moment, but should probably be fixed by turning `isOwned()` into a property.~~ split out