### PR TITLE
Add feature to replace community hub links with store page links on friend activity feed

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -315,6 +315,7 @@
                     <div data-dynamic-select="community_default_tab"></div>
                     <div data-dynamic="showallachievements"></div>
                     <div data-dynamic="showallstats"></div>
+                    <div data-dynamic="replacecommunityhublinks"></div>
                     <div data-dynamic="hidespamcomments" class="parent_option"></div>
                     <div id="spamcommentregex_list" class="option--sub js-sub-option">
                         <label for="spamcommentregex" data-locale-text="options.spamcommentregex">Regular Expression string:</label>

--- a/src/js/Content/Features/Community/ProfileActivity/CProfileActivity.js
+++ b/src/js/Content/Features/Community/ProfileActivity/CProfileActivity.js
@@ -3,6 +3,7 @@ import {CCommunityBase} from "../CCommunityBase";
 import {CommentHandler} from "../../../Modules/Community/CommentHandler";
 import FHighlightFriendsActivity from "./FHighlightFriendsActivity";
 import FAchievementLink from "./FAchievementLink";
+import FReplaceCommunityHubLinks from "./FReplaceCommunityHubLinks";
 
 export class CProfileActivity extends CCommunityBase {
 
@@ -11,6 +12,7 @@ export class CProfileActivity extends CCommunityBase {
         super(ContextType.PROFILE_ACTIVITY, [
             FHighlightFriendsActivity,
             FAchievementLink,
+            FReplaceCommunityHubLinks,
         ]);
 
         this._registerObserver();

--- a/src/js/Content/Features/Community/ProfileActivity/FReplaceCommunityHubLinks.js
+++ b/src/js/Content/Features/Community/ProfileActivity/FReplaceCommunityHubLinks.js
@@ -1,0 +1,23 @@
+import {SyncedStorage} from "../../../../modulesCore";
+import {CallbackFeature} from "../../../modulesContent";
+
+export default class FReplaceCommunityHubLinks extends CallbackFeature {
+
+    checkPrerequisites() {
+        return SyncedStorage.get("replacecommunityhublinks");
+    }
+
+    setup() {
+        this.callback();
+    }
+
+    callback(parent = document) {
+
+        // Don't replace user-provided links i.e. links in announcements/comments
+        const nodes = parent.querySelectorAll(".blotter_block a:not(.bb_link)");
+
+        for (const node of nodes) {
+            node.href = node.href.replace(/steamcommunity\.com\/(?:app|games)/, "store.steampowered.com/app");
+        }
+    }
+}

--- a/src/js/Content/Features/Community/ProfileActivity/FReplaceCommunityHubLinks.js
+++ b/src/js/Content/Features/Community/ProfileActivity/FReplaceCommunityHubLinks.js
@@ -17,6 +17,7 @@ export default class FReplaceCommunityHubLinks extends CallbackFeature {
         const nodes = parent.querySelectorAll(".blotter_block a:not(.bb_link)");
 
         for (const node of nodes) {
+            if (!node.hasAttribute("href")) { continue; }
             node.href = node.href.replace(/steamcommunity\.com\/(?:app|games)/, "store.steampowered.com/app");
         }
     }

--- a/src/js/Core/GameId.js
+++ b/src/js/Core/GameId.js
@@ -22,8 +22,8 @@ class GameId {
             if (!_text) { return null; }
         }
 
-        // app, market/listing
-        const m = _text.match(/(?:store\.steampowered|steamcommunity)\.com\/(?:app|market\/listings)\/(\d+)\/?/);
+        // app, games (legacy official group page), market/listing
+        const m = _text.match(/(?:store\.steampowered|steamcommunity)\.com\/(?:app|games|market\/listings)\/(\d+)\/?/);
         return m && GameId.parseId(m[1]);
     }
 

--- a/src/js/Core/Storage/SyncedStorage.js
+++ b/src/js/Core/Storage/SyncedStorage.js
@@ -257,6 +257,7 @@ SyncedStorage.defaults = Object.freeze({
     "community_default_tab": "",
     "showallachievements": false,
     "showallstats": true,
+    "replacecommunityhublinks": false,
     "showachinstore": true,
     "hideactivelistings": false,
     "showlowestmarketprice": true,

--- a/src/js/Options/Modules/Data/OptionsSetup.js
+++ b/src/js/Options/Modules/Data/OptionsSetup.js
@@ -185,6 +185,7 @@ export default {
     ],
     "showallachievements": "options.showallachievements",
     "showallstats": "options.showallstats",
+    "replacecommunityhublinks": "options.replacecommunityhublinks",
     "hidespamcomments": "options.hidespamcomments",
     "steamcardexchange": "options.steamcardexchange",
     "wlbuttoncommunityapp": "options.wlbuttoncommunityapp",

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -451,6 +451,7 @@
         "name": "Name",
         "show_alternative_linux_icon": "Show alternative Linux icon",
         "showcomparelinks": "Show \"Compare\" links for achievements on friend activity feed",
+        "replacecommunityhublinks": "Replace community hub links with store page links on friend activity feed",
         "hidetmsymbols": "Trademark and Copyright symbols in game titles",
         "metacritic": "Show Metacritic user scores",
         "opencritic": "Show Opencritic ratings and reviews",


### PR DESCRIPTION
This can technically be rolled into `FHighlightFriendsActivity`, since these links also get checked for highlighting, but I guess it's better to make it a separate feature?

Also replaces and adds highlighting to "followed" links (Steam treats following as joining the app's legacy official group page), though it won't work if the app has a custom group name.

Closes #898.