### PR TITLE
[WIP] FHighlightsTags: fix and simplify removing ds_flag node and ds_flagged class

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1508,6 +1508,16 @@ img.astats_icon {
   vertical-align: baseline;
 }
 
+/* Hide ds_flag and revert the burring/dimming of app images */
+.es_highlighted .ds_flag {
+  display: none;
+}
+.es_highlighted.ds_flagged img,
+.es_highlighted .ds_flagged img {
+  filter: blur(0) !important;
+  opacity: 1 !important;
+}
+
 /*.es_highlighted div:not(.discount_pct):not(.discount_final_price):not(.discount_original_price):not(.main_cap_status):not(.search_released):not(.tab_item_top_tags):not(.tab_item_details) {
 	color: rgba(255, 255, 255, 0.8) !important;
 }*/

--- a/src/js/Content/Features/Common/FHighlightsTags.js
+++ b/src/js/Content/Features/Common/FHighlightsTags.js
@@ -296,46 +296,6 @@ export default class FHighlightsTags extends Feature {
             document.head.appendChild(style);
             style = null;
         }
-
-        let _node = node;
-
-        // Carousel item
-        if (_node.classList.contains("cluster_capsule")) {
-            _node = _node.querySelector(".main_cap_content").parentNode;
-        } else if (_node.classList.contains("large_cap")) {
-
-            // Genre Carousel items
-            _node = _node.querySelector(".large_cap_content");
-        } else if (_node.parentNode.classList.contains("steam_curator_recommendation")
-            && _node.parentNode.classList.contains("big")) {
-            _node = _node.previousElementSibling;
-        }
-
-        // Recommendations on front page when scrolling down
-        if (_node.classList.contains("single")) {
-            _node = _node.querySelector(".gamelink");
-        }
-
-        if (_node.parentNode.parentNode.classList.contains("apps_recommended_by_curators_v2")) {
-            let r = _node.querySelectorAll(".ds_flag");
-            r.forEach(node => node.remove());
-            r = _node.querySelectorAll(".ds_flagged");
-            r.forEach(node => node.classList.remove("ds_flagged"));
-        } else {
-
-            if (_node.classList.contains("info") || _node.classList.contains("spotlight_content")) {
-                _node = _node.parentElement;
-            }
-
-            let r = _node.querySelector(".ds_flag");
-            if (r) { r.remove(); }
-            r = _node.querySelector(".ds_flagged");
-            if (r) {
-                r.classList.remove("ds_flagged");
-            }
-        }
-
-        _node.classList.remove("ds_flagged");
     }
 
     static _highlightItem(node, name) {


### PR DESCRIPTION
Calls to `FHighlightsTags._highlightNode` also removes the redundant ds_flag nodes after applying the highlights, but the code is also ran if `hasDsInfo = false`, which is not only unnecessary, but can also cause errors on the friends activity page, where store app links may be replaced with `iframe`s before this method is called.

An easy fix would be to guard this code, but I'm thinking since this only a visual issue, it can be handled in CSS rather than traversing the DOM to remove the nodes.