### PR TITLE
Show the parent app's support info for DLCs and Soundtracks

### DIFF
--- a/src/js/Content/Features/Store/App/FSupportInfo.js
+++ b/src/js/Content/Features/Store/App/FSupportInfo.js
@@ -1,10 +1,10 @@
-import {HTML, LocalStorage, Localization, SyncedStorage} from "../../../../modulesCore";
+import {GameId, HTML, LocalStorage, Localization, SyncedStorage} from "../../../../modulesCore";
 import {Background, Feature} from "../../../modulesContent";
 
 export default class FSupportInfo extends Feature {
 
     async checkPrerequisites() {
-        if (this.context.isDlc() || !SyncedStorage.get("showsupportinfo")) { return false; }
+        if (!SyncedStorage.get("showsupportinfo")) { return false; }
 
         let cache = LocalStorage.get("support_info", null);
 
@@ -16,7 +16,8 @@ export default class FSupportInfo extends Feature {
             };
         }
 
-        const appid = this.context.appid;
+        // Attempt to get appid of parent app first for DLCs and Soundtracks
+        const appid = GameId.getAppid(document.querySelector(".glance_details a")) || this.context.appid;
         this._supportInfo = cache.data[appid];
 
         if (!this._supportInfo) {

--- a/src/js/Content/Features/Store/App/FSupportInfo.js
+++ b/src/js/Content/Features/Store/App/FSupportInfo.js
@@ -38,34 +38,30 @@ export default class FSupportInfo extends Feature {
 
     apply() {
 
-        const url = this._supportInfo.url;
-        const email = this._supportInfo.email;
+        const {url, email} = this._supportInfo;
+        const links = [];
 
-        let support = "";
         if (url) {
-            support += `<a href="${url}">${Localization.str.website}</a>`;
+            links.push(`<a href="${url}">${Localization.str.website}</a>`);
         }
 
         if (email) {
-            if (url) {
-                support += ", ";
-            }
 
             // From https://emailregex.com/
             const emailRegex
                 = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
             if (emailRegex.test(email)) {
-                support += `<a href="mailto:${email}">${Localization.str.email}</a>`;
+                links.push(`<a href="mailto:${email}">${Localization.str.email}</a>`);
             } else {
-                support += `<a href="${email}">${Localization.str.contact}</a>`;
+                links.push(`<a href="${email}">${Localization.str.contact}</a>`);
             }
         }
 
         HTML.beforeEnd(".glance_ctn_responsive_left",
             `<div class="release_date" style="padding-bottom: 0;">
                 <div class="subtitle column">${Localization.str.support}:</div>
-                <div class="summary column">${support}</div>
+                <div class="summary column">${links.join(", ")}</div>
             </div>`);
     }
 }


### PR DESCRIPTION
Support info is disabled on DLCs, I assume this is to avoid storing duplicate data? But now it is duplicated for Soundtracks as well, so fix this by attempting to fetch the info for the parent app of DLCs and Soundtracks.