### PR TITLE
Restore the ability to press Enter to save a note while typing

### DIFF
--- a/src/js/Content/Features/Store/Common/UserNotes.js
+++ b/src/js/Content/Features/Store/Common/UserNotes.js
@@ -79,6 +79,11 @@ class UserNotes {
             const noteInput = document.getElementById("es_note_input");
             noteInput.focus();
             noteInput.setSelectionRange(0, noteInput.textLength);
+            noteInput.addEventListener("keydown", e => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                    okBtn.trigger("click");
+                }
+            });
 
             deferred.promise(modal);
 


### PR DESCRIPTION
Seems like `_BindOnEnterKeyPressForDialog` skips `textarea` elements, so add back the event listener. "Escape" is handled by Steam already.

Closes #1288.