### PR TITLE
Reimplement fix_app_image_not_found from Enhanced Steam

### DIFF
--- a/src/js/Content/Features/Community/FFixAppImageNotFound.js
+++ b/src/js/Content/Features/Community/FFixAppImageNotFound.js
@@ -1,0 +1,36 @@
+import {GameId} from "../../../modulesCore";
+import {Feature} from "../../modulesContent";
+
+export default class FFixAppImageNotFound extends Feature {
+
+    apply() {
+
+        function fixSrc(node) {
+
+            const appid = GameId.getAppid(node.parentNode.href);
+            if (!appid) { return; }
+
+            const src = `https://cdn.akamai.steamstatic.com/steam/apps/${appid}/capsule_184x69.jpg`;
+
+            const testImg = document.createElement("img");
+            testImg.src = src;
+            testImg.addEventListener("load", () => {
+                node.src = src;
+            });
+        }
+
+        document.querySelectorAll("img[src$='338200c5d6c4d9bdcf6632642a2aeb591fb8a5c2.gif']")
+            .forEach(node => fixSrc(node));
+
+        const container = document.querySelector("#games_list_rows");
+        if (!container) { return; }
+
+        new MutationObserver(mutations => {
+            for (const {target} of mutations) {
+                if (target.src.endsWith("338200c5d6c4d9bdcf6632642a2aeb591fb8a5c2.gif")) {
+                    fixSrc(target);
+                }
+            }
+        }).observe(container, {"subtree": true, "attributeFilter": ["src"]});
+    }
+}

--- a/src/js/Content/Features/Community/Games/CGames.js
+++ b/src/js/Content/Features/Community/Games/CGames.js
@@ -1,6 +1,7 @@
 import ContextType from "../../../Modules/Context/ContextType";
 import {CCommunityBase} from "../CCommunityBase";
 import FEarlyAccess from "../../Common/FEarlyAccess";
+import FFixAppImageNotFound from "../FFixAppImageNotFound";
 import FGamesStats from "./FGamesStats";
 import FCommonGames from "./FCommonGames";
 import FGamelistAchievements from "./FGamelistAchievements";
@@ -16,6 +17,7 @@ export class CGames extends CCommunityBase {
         }
 
         super(ContextType.GAMES, [
+            FFixAppImageNotFound,
             FGamesStats,
             FCommonGames,
             FGamelistAchievements,

--- a/src/js/Content/Features/Community/ProfileHome/CProfileHome.js
+++ b/src/js/Content/Features/Community/ProfileHome/CProfileHome.js
@@ -1,6 +1,7 @@
 import {ContextType, ProfileData} from "../../../modulesContent";
 import {CCommunityBase} from "../CCommunityBase";
 import FEarlyAccess from "../../Common/FEarlyAccess";
+import FFixAppImageNotFound from "../FFixAppImageNotFound";
 import FCommunityProfileLinks from "./FCommunityProfileLinks";
 import FWishlistProfileLink from "./FWishlistProfileLink";
 import FSupporterBadges from "./FSupporterBadges";
@@ -40,6 +41,7 @@ export class CProfileHome extends CCommunityBase {
         ProfileData.promise();
 
         super(ContextType.PROFILE_HOME, [
+            FFixAppImageNotFound,
             FCommunityProfileLinks,
             FWishlistProfileLink,
             FSupporterBadges,


### PR DESCRIPTION
Closes #1294.

This feature was also applied on wishlists in ES, but I don't think it's needed now.