### PR TITLE
Improve the logic for finding in-game appid on profile home page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
         "DOMPurify": "readonly"
     },
     "parserOptions": {
-        "ecmaVersion": 2018,
+        "ecmaVersion": 2020,
         "sourceType": "module"
     },
     "overrides": [


### PR DESCRIPTION
Related to #1007.

If the deprecated "report abuse" form isn't available, try to get the appid from the profile's miniprofile hover content. Now this feature also works when not logged in, and should be more future-proof. The additional request shouldn't be a problem, since the exact same page is also fetched if you simply mouseover the avatar.