### PR TITLE
Ensure Steam's handlers are able to select the original order_input

### DIFF
--- a/src/js/Content/Features/Store/Wishlist/FKeepEditableRanking.js
+++ b/src/js/Content/Features/Store/Wishlist/FKeepEditableRanking.js
@@ -53,7 +53,7 @@ export default class FKeepEditableRanking extends CallbackFeature {
             newHoverHandle.classList.add("as_hover_handle");
             newHoverHandle.draggable = false;
             newHoverHandle.querySelector("img").remove();
-            hoverHandle.insertAdjacentElement("beforebegin", newHoverHandle);
+            hoverHandle.insertAdjacentElement("afterend", newHoverHandle);
 
             const input = hoverHandle.querySelector(".order_input");
             const newInput = newHoverHandle.querySelector(".order_input");


### PR DESCRIPTION
Fixes https://github.com/IsThereAnyDeal/AugmentedSteam/issues/1293#issuecomment-961454031

I don't fully understand why this was broken in the first place, but AFAICT this fixes it.