### PR TITLE
Fix quick sell and market overview not appearing for some non-Steam items

### DIFF
--- a/src/js/Content/Features/Community/Inventory/CInventory.js
+++ b/src/js/Content/Features/Community/Inventory/CInventory.js
@@ -53,7 +53,7 @@ export class CInventory extends CCommunityBase {
                 window.Messenger.postMessage("marketInfo", {
                     "view": iActiveSelectView,
                     "sessionId": g_sessionID,
-                    "assetId": Number(g_ActiveInventory.selectedItem.assetid),
+                    "assetId": g_ActiveInventory.selectedItem.assetid, // DO NOT try to convert this to a number as the value might exceed Number.MAX_SAFE_INTEGER
                     "contextId": Number(g_ActiveInventory.selectedItem.contextid),
                     "globalId": Number(g_ActiveInventory.appid),
                     "walletCurrency": g_rgWalletInfo.wallet_currency,

--- a/src/js/Content/Features/Community/Inventory/CInventory.js
+++ b/src/js/Content/Features/Community/Inventory/CInventory.js
@@ -54,19 +54,31 @@ export class CInventory extends CCommunityBase {
                     ? g_ActiveInventory.selectedItem.description.market_fee
                     : g_rgWalletInfo.wallet_publisher_fee_percent_default;
 
+                const contextId = Number(g_ActiveInventory.selectedItem.contextid);
+                const globalId = Number(g_ActiveInventory.appid);
+
+                let appid = null;
+                let isBooster = false;
+
+                // Only parse hashname if the item is a Steam item
+                if (contextId === 6 && globalId === 753) {
+                    appid = parseInt(hashName);
+                    isBooster = /Booster Pack/i.test(hashName);
+                }
+
                 window.Messenger.postMessage("marketInfo", {
                     "view": iActiveSelectView,
                     "sessionId": g_sessionID,
                     "assetId": g_ActiveInventory.selectedItem.assetid, // DO NOT try to convert this to a number as the value might exceed Number.MAX_SAFE_INTEGER
-                    "contextId": Number(g_ActiveInventory.selectedItem.contextid),
-                    "globalId": Number(g_ActiveInventory.appid),
+                    contextId,
+                    globalId,
                     "walletCurrency": g_rgWalletInfo.wallet_currency,
                     "marketable": g_ActiveInventory.selectedItem.description.marketable,
                     hashName,
                     publisherFee,
                     restriction,
-                    "appid": parseInt(hashName) || null,
-                    "isBooster": /Booster Pack/i.test(hashName),
+                    appid,
+                    isBooster,
                 });
             });
             /* eslint-enable no-undef, camelcase */

--- a/src/js/Content/Features/Community/Inventory/CInventory.js
+++ b/src/js/Content/Features/Community/Inventory/CInventory.js
@@ -41,8 +41,12 @@ export class CInventory extends CCommunityBase {
                 // https://github.com/SteamDatabase/SteamTracking/blob/b3abe9c82f9e9d260265591320cac6304e500e58/steamcommunity.com/public/javascript/economy_common.js#L161
                 const hashName = window.SteamFacade.getMarketHashName(g_ActiveInventory.selectedItem.description);
 
+                /*
+                 * See https://github.com/IsThereAnyDeal/AugmentedSteam/pull/1047#discussion_r571444376
+                 * Update: For non-Steam items, the text may not have a color, so test date only
+                 */
                 const restriction = Array.isArray(g_ActiveInventory.selectedItem.description.owner_descriptions)
-                    ? g_ActiveInventory.selectedItem.description.owner_descriptions.some(el => /\[date\]\d+\[\/date\]/.test(el.value) && el.color === "A75124")
+                    ? g_ActiveInventory.selectedItem.description.owner_descriptions.some(el => /\[date\]\d+\[\/date\]/.test(el.value))
                     : false;
 
                 // https://github.com/SteamDatabase/SteamTracking/blob/f26cfc1ec42b8a0c27ca11f4343edbd8dd293255/steamcommunity.com/public/javascript/economy_v2.js#L4468

--- a/src/js/Content/Features/Community/Inventory/FOneClickGemsOption.js
+++ b/src/js/Content/Features/Community/Inventory/FOneClickGemsOption.js
@@ -10,6 +10,8 @@ export default class FOneClickGemsOption extends CallbackFeature {
 
     callback({view, sessionId, assetId, appid}) {
 
+        if (!appid) { return; }
+
         // scrap link is always present, replace the link to avoid attaching multiple listeners
         const scrapLink = document.getElementById(`iteminfo${view}_item_scrap_link`);
         const newScrapLink = scrapLink.cloneNode(true);

--- a/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
+++ b/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
@@ -2,7 +2,6 @@ import {HTML, Localization, SyncedStorage} from "../../../../modulesCore";
 import {CallbackFeature, CurrencyManager, RequestData} from "../../../modulesContent";
 import {Page} from "../../Page";
 
-// TODO Support non-Steam items
 export default class FQuickSellOptions extends CallbackFeature {
 
     checkPrerequisites() {


### PR DESCRIPTION
Found by testing this item from Discord: https://discord.com/channels/301903094080339968/350436837161959424/914137471367913482