### PR TITLE
Only initiate Sortbox when needed

### DIFF
--- a/src/js/Content/Features/Page.js
+++ b/src/js/Content/Features/Page.js
@@ -4,7 +4,6 @@ import {
     CurrencyManager,
     DOMHelper,
     ITAD, Messenger, ProgressBar,
-    Sortbox,
     UpdateHandler,
     User
 } from "../modulesContent";
@@ -98,7 +97,6 @@ class Page {
         AugmentedSteam.init();
         UpdateHandler.checkVersion(AugmentedSteam.clearCache);
         ITAD.create();
-        Sortbox.init();
         this._pageSpecificFeatures();
 
         const context = new ContextClass();

--- a/src/js/Content/Modules/Widgets/SortBox.js
+++ b/src/js/Content/Modules/Widgets/SortBox.js
@@ -10,19 +10,14 @@ class Sortbox {
         this._activeDropLists = {};
         this._lastSelectHideTime = 0;
 
-        document.addEventListener("mousedown", e => this._handleMouseClick(e));
-    }
-
-    static _handleMouseClick(e) {
-        for (const key of Object.keys(this._activeDropLists)) {
-            if (!this._activeDropLists[key]) { continue; }
-
-            const ulAboveEvent = e.target.closest("ul");
-
-            if (ulAboveEvent && ulAboveEvent.id === `${key}_droplist`) { continue; }
-
-            this._hide(key);
-        }
+        // Hide droplist when clicking outside
+        document.addEventListener("mousedown", e => {
+            for (const key of Object.keys(this._activeDropLists)) {
+                if (this._activeDropLists[key] && !e.target.closest(`#${key}_container`)) {
+                    this._hide(key);
+                }
+            }
+        });
     }
 
     static _highlightItem(id, index, bSetSelected) {
@@ -135,7 +130,7 @@ class Sortbox {
         const box = HTML.element(
             `<div class="es-sortbox es-sortbox--${name}">
                 <div class="es-sortbox__label">${Localization.str.sort_by}</div>
-                <div class="es-sortbox__container">
+                <div id="${id}_container" class="es-sortbox__container">
                     <input id="${id}" type="hidden" name="${name}" value="${initialOption}">
                     <a class="trigger" id="${id}_trigger"></a>
                     <div class="es-dropdown">
@@ -203,5 +198,7 @@ class Sortbox {
         return box;
     }
 }
+
+Sortbox.init();
 
 export {Sortbox};

--- a/src/js/Content/Modules/Widgets/SortBox.js
+++ b/src/js/Content/Modules/Widgets/SortBox.js
@@ -73,7 +73,9 @@ class Sortbox {
     }
 
     static _onBlur(id) {
-        if (!this._classCheck(document.querySelector(`#${id}_trigger`), "activetrigger")) { this._activeDropLists[id] = false; }
+        if (!document.querySelector(`#${id}_trigger`).classList.contains("activetrigger")) {
+            this._activeDropLists[id] = false;
+        }
     }
 
     static _hide(id) {
@@ -103,13 +105,9 @@ class Sortbox {
     }
 
     static _onTriggerClick(id) {
-        if (!this._classCheck(document.querySelector(`#${id}_trigger`), "activetrigger")) {
+        if (!document.querySelector(`#${id}_trigger`).classList.contains("activetrigger")) {
             this._show(id);
         }
-    }
-
-    static _classCheck(element, className) {
-        return new RegExp(`\\b${className}\\b`).test(element.className);
     }
 
     /**

--- a/src/js/Content/Modules/Widgets/SortBox.js
+++ b/src/js/Content/Modules/Widgets/SortBox.js
@@ -82,8 +82,7 @@ class Sortbox {
         const droplist = document.querySelector(`#${id}_droplist`);
         const trigger = document.querySelector(`#${id}_trigger`);
 
-        const d = new Date();
-        this._lastSelectHideTime = d.valueOf();
+        this._lastSelectHideTime = Date.now();
 
         trigger.className = "trigger";
         droplist.className = "dropdownhidden";
@@ -92,8 +91,7 @@ class Sortbox {
     }
 
     static _show(id) {
-        const d = new Date();
-        if (d - this._lastSelectHideTime < 50) { return; }
+        if (Date.now() - this._lastSelectHideTime < 50) { return; }
 
         const droplist = document.querySelector(`#${id}_droplist`);
         const trigger = document.querySelector(`#${id}_trigger`);
@@ -130,12 +128,12 @@ class Sortbox {
                 <div class="es-sortbox__label">${Localization.str.sort_by}</div>
                 <div id="${id}_container" class="es-sortbox__container">
                     <input id="${id}" type="hidden" name="${name}" value="${initialOption}">
-                    <a class="trigger" id="${id}_trigger"></a>
+                    <a id="${id}_trigger" class="trigger"></a>
                     <div class="es-dropdown">
-                        <ul id="${id}_droplist" class="es-dropdown__list dropdownhidden"></ul>
+                        <ul id="${id}_droplist" class="dropdownhidden"></ul>
                     </div>
                 </div>
-                <span class="es-sortbox__reverse">${arrowDown}</span>
+                <span class="es-sortbox__reverse">${reversed ? arrowUp : arrowDown}</span>
             </div>`
         );
 
@@ -162,7 +160,6 @@ class Sortbox {
             reverseEl.textContent = reversed ? arrowUp : arrowDown;
             onChange(input.value.replace(`${id}_`, ""), reversed);
         });
-        if (reversed) { reverseEl.textContent = arrowUp; }
 
         const trigger = box.querySelector(`#${id}_trigger`);
         trigger.addEventListener("focus", () => this._onFocus(id));
@@ -176,8 +173,8 @@ class Sortbox {
 
             let toggle = "inactive";
             if (key === trimmedOption) {
-                box.querySelector(`#${id}`).value = key;
-                box.querySelector(".trigger").textContent = text;
+                input.value = key;
+                trigger.textContent = text;
                 toggle = "highlighted";
             }
 


### PR DESCRIPTION
I think `Sortbox.init` only needs to be called on pages that make use of a sortbox? Also fixed dropdown flashing when clicking on the trigger element while the dropdown is open.