### PR TITLE
Add prefix to class name of youtube links

### DIFF
--- a/src/css/augmentedsteam-chrome.css
+++ b/src/css/augmentedsteam-chrome.css
@@ -22,7 +22,7 @@
   background-image: url("chrome-extension://__MSG_@@extension_id__/img/bartervg.png");
 }
 
-.youtube_btn i {
+.as_youtube_btn i {
   background-image: url("chrome-extension://__MSG_@@extension_id__/img/icon-youtube.png");
 }
 
@@ -80,7 +80,7 @@
   background-image: url("chrome-extension://__MSG_@@extension_id__/img/ico/steamtrades.png");
 }
 .es_sites_icons.es_bartervg_icon:before {
-	background-image: url("chrome-extension://__MSG_@@extension_id__/img/ico/bartervg.png");
+  background-image: url("chrome-extension://__MSG_@@extension_id__/img/ico/bartervg.png");
 }
 .es_sites_icons.es_astats_icon:before {
   background-image: url("chrome-extension://__MSG_@@extension_id__/img/ico/achievementstats.png");

--- a/src/css/augmentedsteam-edge.css
+++ b/src/css/augmentedsteam-edge.css
@@ -22,7 +22,7 @@
   background-image: url("chrome-extension://__MSG_@@extension_id__/img/bartervg.png");
 }
 
-.youtube_btn i {
+.as_youtube_btn i {
   background-image: url("chrome-extension://__MSG_@@extension_id__/img/icon-youtube.png");
 }
 
@@ -80,7 +80,7 @@
   background-image: url("chrome-extension://__MSG_@@extension_id__/img/ico/steamtrades.png");
 }
 .es_sites_icons.es_bartervg_icon:before {
-	background-image: url("chrome-extension://__MSG_@@extension_id__/img/ico/bartervg.png");
+  background-image: url("chrome-extension://__MSG_@@extension_id__/img/ico/bartervg.png");
 }
 .es_sites_icons.es_astats_icon:before {
   background-image: url("chrome-extension://__MSG_@@extension_id__/img/ico/achievementstats.png");

--- a/src/css/augmentedsteam-firefox.css
+++ b/src/css/augmentedsteam-firefox.css
@@ -30,7 +30,7 @@
   background-image: url("moz-extension://__MSG_@@extension_id__/img/bartervg.png");
 }
 
-.youtube_btn i {
+.as_youtube_btn i {
   background-image: url("moz-extension://__MSG_@@extension_id__/img/icon-youtube.png");
 }
 
@@ -87,7 +87,7 @@
   background-image: url("moz-extension://__MSG_@@extension_id__/img/ico/steamtrades.png");
 }
 .es_sites_icons.es_bartervg_icon:before {
-	background-image: url("moz-extension://__MSG_@@extension_id__/img/ico/bartervg.png");
+  background-image: url("moz-extension://__MSG_@@extension_id__/img/ico/bartervg.png");
 }
 .es_sites_icons.es_astats_icon:before {
   background-image: url("moz-extension://__MSG_@@extension_id__/img/ico/achievementstats.png");

--- a/src/js/Content/Features/Store/Common/FExtraLinks.js
+++ b/src/js/Content/Features/Store/Common/FExtraLinks.js
@@ -103,19 +103,19 @@ export default class FExtraLinks extends Feature {
                 },
                 {
                     "id": "showyoutube",
-                    "className": "youtube_btn",
+                    "className": "as_youtube_btn",
                     "link": `https://www.youtube.com/results?search_query=${encodeURIComponent(appName)}`,
                     "text": Localization.str.view_on_website.replace("__website__", "YouTube"),
                 },
                 {
                     "id": "showyoutubegameplay",
-                    "className": "youtube_btn",
+                    "className": "as_youtube_btn",
                     "link": `https://www.youtube.com/results?search_query=${encodeURIComponent(`${appName} "PC Gameplay"`)}`,
                     "text": Localization.str.youtube_gameplay,
                 },
                 {
                     "id": "showyoutubereviews",
-                    "className": "youtube_btn",
+                    "className": "as_youtube_btn",
                     "link": `https://www.youtube.com/results?search_query=${encodeURIComponent(`${appName} "PC" intitle:Review`)}`,
                     "text": Localization.str.youtube_reviews,
                 },


### PR DESCRIPTION
Avoid clash with a filter rule in one of the stock lists commonly included in ad blockers.

Reported on Discord:
https://discord.com/channels/301903094080339968/568744564261781504/916128124658384906