### PR TITLE
Fix inventory page match pattern

### DIFF
--- a/src/js/Content/Features/Community/Inventory/PInventory.js
+++ b/src/js/Content/Features/Community/Inventory/PInventory.js
@@ -1,5 +1,12 @@
 import {CommunityPage} from "../../CommunityPage";
 import {CInventory} from "./CInventory";
+import {CCommunityBase} from "../CCommunityBase";
 
-(new CommunityPage()).run(CInventory);
+const page = new CommunityPage();
 
+// This regex can't be translated to a match pattern / glob combination in the manifest
+if (/^\/(?:id|profiles)\/[^/]+\/inventory\/?$/.test(window.location.pathname)) {
+    page.run(CInventory);
+} else {
+    page.run(CCommunityBase);
+}


### PR DESCRIPTION
Mainly to avoid loading inventory.js when on https://steamcommunity.com/my/inventoryhistory/.
I couldn't make this work with a match pattern in the manifest, so I copied how it was done for profile_home.js.