### PR TITLE
Fix clipped bottom section on the interactive recommender page

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -32,6 +32,13 @@
 .collectionChoiceSection {
   height: 400px;
 }
+/**
+ * https://github.com/IsThereAnyDeal/AugmentedSteam/pull/1329
+ * Fix clipped bottom section on the interactive recommender page
+ */
+[class^=interactiverecommender_BottomSection] {
+  overflow-y: visible !important;
+}
 
 /* Back To Top button */
 .es_btt {


### PR DESCRIPTION
https://store.steampowered.com/recommender/

Since a while ago Steam clipped the bottom section of the interactive recommender page for whatever reason:
![螢幕擷取畫面 2021-12-13 054232](https://user-images.githubusercontent.com/54083835/145730804-7ece43bb-1070-432f-a0fe-a120ae452bb8.jpg)

This fixes it so the remaining items show up:
![螢幕擷取畫面 2021-12-13 054309](https://user-images.githubusercontent.com/54083835/145730806-95026dae-e312-49a6-92dd-e6bcc36d4423.jpg)
