### PR TITLE
Get store sessionId from "about" page

### DIFF
--- a/src/js/Background/Modules/SteamStoreApi.js
+++ b/src/js/Background/Modules/SteamStoreApi.js
@@ -112,7 +112,7 @@ class SteamStoreApi extends Api {
         const self = SteamStoreApi;
 
         // TODO what's the minimal page we can load here to get sessionId?
-        const html = await self.getPage("/news/");
+        const html = await self.getPage("/about/");
         return HTMLParser.getVariableFromText(html, "g_sessionID", "string");
     }
 


### PR DESCRIPTION
Minor -- but I think the "about" page is smaller than the revamped news hub in terms of document size.