### PR TITLE
Add toggle button to show/hide comments under group announcements on friend activity feed

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1802,6 +1802,15 @@ img.astats_icon {
 }
 
 /***************************************
+ * Friend activity page
+ * FToggleComments
+ **************************************/
+.as_comments_toggle {
+  float: right;
+  margin-right: 6px;
+}
+
+/***************************************
  * Market
  * add_market_sort()
  **************************************/

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -312,13 +312,17 @@
                 </div>
 
                 <div class="section js-section">
-                    <h2 data-locale-text="options.general" class="js-section-head">General</h2>
+                    <h2 data-locale-text="options.friend_activity" class="js-section-head">Friend Activity Feed</h2>
+                    <div data-dynamic="replacecommunityhublinks"></div>
+                    <div data-dynamic="hideannouncementcomments"></div>
+                </div>
 
+                <div class="section js-section">
+                    <h2 data-locale-text="options.general" class="js-section-head">General</h2>
                     <div data-dynamic-select="show_profile_link_images"></div>
                     <div data-dynamic-select="community_default_tab"></div>
                     <div data-dynamic="showallachievements"></div>
                     <div data-dynamic="showallstats"></div>
-                    <div data-dynamic="replacecommunityhublinks"></div>
                     <div data-dynamic="hidespamcomments" class="parent_option"></div>
                     <div id="spamcommentregex_list" class="option--sub js-sub-option">
                         <label for="spamcommentregex" data-locale-text="options.spamcommentregex">Regular Expression string:</label>

--- a/src/js/Content/Features/Community/ProfileActivity/CProfileActivity.js
+++ b/src/js/Content/Features/Community/ProfileActivity/CProfileActivity.js
@@ -5,6 +5,7 @@ import FEarlyAccess from "../../Common/FEarlyAccess";
 import FHighlightFriendsActivity from "./FHighlightFriendsActivity";
 import FAchievementLink from "./FAchievementLink";
 import FReplaceCommunityHubLinks from "./FReplaceCommunityHubLinks";
+import FToggleComments from "./FToggleComments";
 
 export class CProfileActivity extends CCommunityBase {
 
@@ -14,6 +15,7 @@ export class CProfileActivity extends CCommunityBase {
             FHighlightFriendsActivity,
             FAchievementLink,
             FReplaceCommunityHubLinks,
+            FToggleComments,
         ]);
 
         FEarlyAccess.show(document.querySelectorAll(".blotter_gamepurchase_logo, .gameLogoHolder_default"));

--- a/src/js/Content/Features/Community/ProfileActivity/FToggleComments.js
+++ b/src/js/Content/Features/Community/ProfileActivity/FToggleComments.js
@@ -1,0 +1,55 @@
+import {HTML, Localization, SyncedStorage} from "../../../../modulesCore";
+import {CallbackFeature, ConfirmDialog} from "../../../modulesContent";
+
+export default class FToggleComments extends CallbackFeature {
+
+    setup() {
+        this._btnEl = HTML.element('<span class="btn_grey_grey btn_small_thin as_comments_toggle"><span></span></span>');
+
+        this.callback();
+    }
+
+    callback(parent = document) {
+
+        const nodes = parent.querySelectorAll(".blotter_userstatus[id^=group_announcement]");
+        const hide = SyncedStorage.get("hideannouncementcomments");
+
+        for (const node of nodes) {
+
+            const commentArea = node.querySelector(".commentthread_area");
+            let btnEl = node.querySelector(".as_comments_toggle");
+
+            if (!btnEl) {
+                btnEl = this._btnEl.cloneNode(true);
+                btnEl.addEventListener("click", () => this._clickHandler(commentArea, btnEl));
+                node.querySelector(".blotter_viewallcomments_container").append(btnEl);
+            }
+
+            this._toggleComments(commentArea, btnEl, hide);
+        }
+    }
+
+    _clickHandler(commentArea, btnEl) {
+
+        if (!SyncedStorage.has("hideannouncementcomments")) {
+
+            ConfirmDialog.openFeatureHint(Localization.str.options.hideannouncementcomments)
+                .then(result => {
+                    const hide = result === "OK";
+                    SyncedStorage.set("hideannouncementcomments", hide);
+
+                    if (hide) {
+                        this.callback(); // Hide all currently visible comment areas
+                    }
+                });
+        }
+
+        this._toggleComments(commentArea, btnEl, !btnEl.classList.contains("as-comments-hidden"));
+    }
+
+    _toggleComments(commentArea, btnEl, hide) {
+        commentArea.style.display = hide ? "none" : "";
+        btnEl.classList[hide ? "add" : "remove"]("as-comments-hidden");
+        btnEl.querySelector("span").textContent = Localization.str[hide ? "show_comments" : "hide_comments"];
+    }
+}

--- a/src/js/Content/Modules/Widgets/ConfirmDialog.js
+++ b/src/js/Content/Modules/Widgets/ConfirmDialog.js
@@ -1,4 +1,5 @@
 import {Page} from "../../Features/Page";
+import {Localization} from "../../../Core/Localization/Localization";
 
 class ConfirmDialog {
 
@@ -22,6 +23,15 @@ class ConfirmDialog {
             strSecondaryActionButton
         ],
         true);
+    }
+
+    static openFeatureHint(optionStr) {
+        return this.open(
+            "Augmented Steam",
+            `${Localization.str.feature_hint.desc}<br><br>${optionStr}<br><br>${Localization.str.feature_hint.reminder}`,
+            Localization.str.thewordyes,
+            Localization.str.thewordno
+        );
     }
 }
 

--- a/src/js/Core/Storage/SyncedStorage.js
+++ b/src/js/Core/Storage/SyncedStorage.js
@@ -176,6 +176,7 @@ SyncedStorage.defaults = Object.freeze({
     "showallachievements": false,
     "showallstats": true,
     "replacecommunityhublinks": false,
+    "hideannouncementcomments": false,
     "showachinstore": true,
     "hideactivelistings": false,
     "showlowestmarketprice": true,

--- a/src/js/Options/Modules/Data/OptionsSetup.js
+++ b/src/js/Options/Modules/Data/OptionsSetup.js
@@ -160,6 +160,10 @@ export default {
     "profile_showcase_own_twitch": "options.profile_showcase_own_twitch",
     "profile_showcase_twitch_profileonly": "options.profile_showcase_twitch_profileonly",
 
+    // friend activity
+    "replacecommunityhublinks": "options.replacecommunityhublinks",
+    "hideannouncementcomments": "options.hideannouncementcomments",
+
     // community general
     "show_profile_link_images": [
         "options.profile_link_images",
@@ -186,7 +190,6 @@ export default {
     ],
     "showallachievements": "options.showallachievements",
     "showallstats": "options.showallstats",
-    "replacecommunityhublinks": "options.replacecommunityhublinks",
     "hidespamcomments": "options.hidespamcomments",
     "steamcardexchange": "options.steamcardexchange",
     "wlbuttoncommunityapp": "options.wlbuttoncommunityapp",

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -1,5 +1,13 @@
 {
     "download_demo_header": "Download __gamename__ Demo",
+    "feature_hint": {
+        "desc": "Would you like to enable the following feature?",
+        "reminder": "You can change your preferences through the options page later."
+    },
+    "thewordyes": "Yes",
+    "thewordno": "No",
+    "show_comments": "Show Comments",
+    "hide_comments": "Hide Comments",
     "calc_workshop_size": {
         "file_size": "File size __size__",
         "finished": "Finished",
@@ -451,7 +459,8 @@
         "name": "Name",
         "show_alternative_linux_icon": "Show alternative Linux icon",
         "showcomparelinks": "Show \"Compare\" links for achievements on friend activity feed",
-        "replacecommunityhublinks": "Replace community hub links with store page links on friend activity feed",
+        "replacecommunityhublinks": "Replace community hub links with store page links",
+        "hideannouncementcomments": "Hide comments under all group announcements by default",
         "hidetmsymbols": "Trademark and Copyright symbols in game titles",
         "metacritic": "Show Metacritic user scores",
         "opencritic": "Show Opencritic ratings and reviews",
@@ -567,6 +576,7 @@
         "inventory": "Inventory",
         "profile": "Profile",
         "group": "Group",
+        "friend_activity": "Friend Activity Feed",
         "group_links": "Options for links to 3rd party sites",
         "show_languagewarning": "Show warning if browsing in a language other than",
         "homepage": "Homepage",


### PR DESCRIPTION
Closes #1280.

Also...
1. Added a new section "Friend Activity Feed" to the options page to house related options.
2. Added a reusable dialog that displays a "feature hint" notice when the user interacts with a feature for the first time.
![螢幕擷取畫面 2021-12-24 063904](https://user-images.githubusercontent.com/54083835/147297031-08250220-60de-4279-8655-f35a8458faa2.jpg)
This is to avoid duplicate translation efforts, since otherwise every time we add a new feature, we'll need an additional translation string similar to the option for the dialog description. Need suggestions for the style and wording.
