### PR TITLE
Rename Uplay to Ubisoft Connect / Ubisoft Store as needed & minor DRM capitalisation changes

### DIFF
--- a/src/js/Content/Features/Store/Common/FDRMWarnings.js
+++ b/src/js/Content/Features/Store/Common/FDRMWarnings.js
@@ -99,13 +99,13 @@ export default class FDRMWarnings extends Feature {
 
         const drmNames = [
             [gfwl, "Games for Windows Live"],
-            [uplay, "Ubisoft Uplay"],
+            [uplay, "Ubisoft Connect"],
             [securom, "SecuROM"],
             [tages, "Tages"],
-            [stardock, "Stardock Account Required"],
+            [stardock, "Stardock Account required"],
             [rockstar, "Rockstar Social Club"],
             [kalypso, "Kalypso Launcher"],
-            [denuvo, "Denuvo Anti-tamper"],
+            [denuvo, "Denuvo Anti-Tamper"],
             [origin, "EA Origin"],
             [xbox, "Microsoft Xbox Live"],
         ].flatMap(([enabled, name]) => { return enabled ? [name] : []; });

--- a/src/js/Options/Modules/Data/StoreList.js
+++ b/src/js/Options/Modules/Data/StoreList.js
@@ -211,7 +211,7 @@ export const StoreList = [
     },
     {
         "id": "uplay",
-        "title": "Uplay",
+        "title": "Ubisoft Store",
         "color": "#01657a"
     },
     {


### PR DESCRIPTION
( Core issue was instead fixed in #1344 )

~~https://store.steampowered.com/app/1461100/International_Basketball_Manager_22/ is incorrectly identified as an Ubisoft game due to the UPLAY name. I sought to fix this,~~ made minor other improvements on the way.

Additional talking points re FDRMWarnings.js:
- should TAGES DRM be called Tages or TAGES or even Tagès? Steam Store pages are inconsistent in that regard.
- some Ubisoft games require their launcher but don't admit to it, like https://store.steampowered.com/app/647590/Space_Junkies/ and https://store.steampowered.com/app/641080/Trials_Rising/ ; this could be hard-coded akin to the override for excluding certain apps:

```
return !this.context.type === ContextType.APP || (
    this.context.appid !== 21690 // Resident Evil 5, at Capcom's request
    && this.context.appid !== 1157970 // Special K
);
```

(but playing _store police_ adds quite a maintenance overhead)