### PR TITLE
Fix errors on apps with no reviews or too few reviews to show playtime filters

### DIFF
--- a/src/js/Content/Features/Store/App/FSaveReviewFilters.js
+++ b/src/js/Content/Features/Store/App/FSaveReviewFilters.js
@@ -72,7 +72,7 @@ export default class FSaveReviewFilters extends Feature {
                  */
                 f.jq("input[name=review_playtime_preset]").attr("checked", false); // uncheck all radio buttons
 
-                if (max == 0) {
+                if (max === 0) {
                     f.jq(`#review_playtime_preset_${min}`).attr("checked", true);
                 }
 


### PR DESCRIPTION
Playtime filters may not be available on apps with too few reviews, so avoid saving undefined values. The playtime filter shows up erroneously in this case, but that's Steam's problem. Fixup #1337.

Store page to test with: https://store.steampowered.com/app/1838320/OPUS_Vol1/