### PR TITLE
Fix groups home features not loading when reloading a subpage, minor refactoring

### DIFF
--- a/src/js/Content/Features/Community/GroupHome/CGroupHome.js
+++ b/src/js/Content/Features/Community/GroupHome/CGroupHome.js
@@ -6,23 +6,17 @@ import FGroupLinks from "./FGroupLinks";
 export class CGroupHome extends CCommunityBase {
 
     constructor() {
+        // Don't apply features if there's an error message (e.g. non-existent group)
+        if (document.getElementById("message") !== null) {
+            super(ContextType.GROUP_HOME);
+            return;
+        }
+
         super(ContextType.GROUP_HOME, [
             FFriendsInviteButton,
             FGroupLinks,
         ]);
-    }
 
-    get groupId() {
-
-        if (this._groupId) { return this._groupId; }
-
-        if (document.getElementById("leave_group_form")) {
-            this._groupId = document.querySelector("input[name=groupId]").value;
-        } else {
-            this._groupId = document.querySelector(".joinchat_bg").getAttribute("onclick")
-                .split("'")[1];
-        }
-
-        return this._groupId;
+        this.groupId = document.querySelector("input[name=groupId], input[name=abuseID]").value;
     }
 }

--- a/src/js/Content/Features/Community/GroupHome/FGroupLinks.js
+++ b/src/js/Content/Features/Community/GroupHome/FGroupLinks.js
@@ -5,12 +5,6 @@ export default class FGroupLinks extends Feature {
 
     apply() {
 
-        let iconType = "none";
-        const images = SyncedStorage.get("show_profile_link_images");
-        if (images !== "none") {
-            iconType = images === "color" ? "color" : "gray";
-        }
-
         const links = [
             {
                 "id": "steamgifts",
@@ -20,9 +14,11 @@ export default class FGroupLinks extends Feature {
         ];
 
         let html = "";
-        for (const link of links) {
-            if (!SyncedStorage.get(`group_${link.id}`)) { continue; }
-            html += CommunityUtils.makeProfileLink(link.id, link.link, link.name, iconType);
+        const iconType = SyncedStorage.get("show_profile_link_images");
+
+        for (const {id, link, name} of links) {
+            if (!SyncedStorage.get(`group_${id}`)) { continue; }
+            html += CommunityUtils.makeProfileLink(id, link, name, iconType);
         }
 
         if (html) {

--- a/src/js/Content/Features/Community/GroupHome/PGroupHome.js
+++ b/src/js/Content/Features/Community/GroupHome/PGroupHome.js
@@ -1,12 +1,4 @@
 import {CommunityPage} from "../../CommunityPage";
 import {CGroupHome} from "./CGroupHome";
-import {CCommunityBase} from "../CCommunityBase";
 
-const page = new CommunityPage();
-
-// This regex can't be translated to a match pattern / glob combination in the manifest
-if (/^\/groups\/[^/]+\/?$/.test(window.location.pathname)) {
-    page.run(CGroupHome);
-} else {
-    page.run(CCommunityBase);
-}
+(new CommunityPage()).run(CGroupHome);

--- a/src/js/Content/Features/Community/ProfileHome/CProfileHome.js
+++ b/src/js/Content/Features/Community/ProfileHome/CProfileHome.js
@@ -19,8 +19,8 @@ import FPinnedBackground from "./FPinnedBackground";
 export class CProfileHome extends CCommunityBase {
 
     constructor() {
-        // If there is an error message, like profile does not exists.
-        if (document.getElementById("message")) {
+        // Don't apply features if there's an error message (e.g. non-existent profile)
+        if (document.getElementById("message") !== null) {
             super(ContextType.PROFILE_HOME);
             return;
         }


### PR DESCRIPTION
A subpage is any of the announcements/discussions/members... tabs. Should be fine to load group_home.js on all community urls that start with /groups/.