### PR TITLE
FPackageInfoButton: clarify and simplify checks

### DIFF
--- a/src/js/Content/Features/Store/App/FPackageInfoButton.js
+++ b/src/js/Content/Features/Store/App/FPackageInfoButton.js
@@ -8,13 +8,20 @@ export default class FPackageInfoButton extends Feature {
     }
 
     apply() {
+
+        /**
+         * Exclude
+         * 1. free items (no form element to get subid, excluded by class selector)
+         * 2. blurred out items (no purchase option thus no form element to get subid)
+         * 3. subscriptions (no subid)
+         * 4. bundles
+         */
         for (const node of document.querySelectorAll(
-            ".game_area_purchase_game_wrapper:not(.bundle_hidden_by_preferences):not(.game_purchase_sub_dropdown)"
+            ".game_area_purchase_game_wrapper:not(.bundle_hidden_by_preferences, .game_purchase_sub_dropdown, .dynamic_bundle_description)"
         )) {
-            if (node.querySelector(".btn_packageinfo")) { return; } // TODO is it right to return here or in the if clause below?
 
             const subid = node.querySelector("input[name=subid]");
-            if (!subid) { return; }
+            if (!subid) { continue; } // This should never happen; non-applicable items should ideally be excluded by the selector
 
             HTML.afterBegin(node.querySelector(".game_purchase_action"),
                 `<div class="game_purchase_action_bg">


### PR DESCRIPTION
I think the original intention behind checking for `.btn_packageinfo` is to exclude bundles, and since bundles are sorted to the bottom, `return` here won't cause problems. Still, it might be better to exclude items by the selector instead.