### PR TITLE
Avoid highlighting and replacing announcement header links

### DIFF
--- a/src/js/Content/Features/Community/ProfileActivity/FHighlightFriendsActivity.js
+++ b/src/js/Content/Features/Community/ProfileActivity/FHighlightFriendsActivity.js
@@ -10,18 +10,19 @@ export default class FHighlightFriendsActivity extends CallbackFeature {
 
     callback(parent = document) {
 
-        const aNodes = Array.from(parent.querySelectorAll(".blotter_block")).reduce((acc, cur) => {
-            acc.push(
-                // Don't highlight images of your friends' game purchases and don't highlight dynamic links as they will get replaced by https://github.com/SteamDatabase/SteamTracking/blob/3552ed4337cd76a5cf0c08ff4d4569d94ef6d4be/steamcommunity.com/public/shared/javascript/shared_global.js#L1512
-                ...Array.from(cur.querySelectorAll("a:not(.blotter_gamepurchase_logo,[id^='dynamiclink_'])"))
-                    .filter(link => (GameId.getAppid(link) !== null && link.childElementCount <= 1)
+        /**
+         * Don't highlight images of your friends' game purchases and dynamic links
+         * Dynamic links will get replaced by https://github.com/SteamDatabase/SteamTracking/blob/3552ed4337cd76a5cf0c08ff4d4569d94ef6d4be/steamcommunity.com/public/shared/javascript/shared_global.js#L1512
+         */
+        const nodes = Array.from(parent.querySelectorAll(".blotter_block a[href]:not(.blotter_gamepurchase_logo, [id^='dynamiclink_'])"))
+            .filter(link => (GameId.getAppid(link) !== null && link.childElementCount <= 1)
 
                 // https://github.com/IsThereAnyDeal/AugmentedSteam/pull/470#pullrequestreview-284928257
-                && (link.childElementCount !== 1 || !link.closest(".vote_header")))
-            );
-            return acc;
-        }, []);
+                && (link.childElementCount !== 1 || !link.closest(".vote_header"))
 
-        FHighlightsTags.highlightAndTag(aNodes, false);
+                // https://github.com/IsThereAnyDeal/AugmentedSteam/issues/1368
+                && !link.parentElement.classList.contains("blotter_group_announcement_headline"));
+
+        FHighlightsTags.highlightAndTag(nodes, false);
     }
 }

--- a/src/js/Content/Features/Community/ProfileActivity/FReplaceCommunityHubLinks.js
+++ b/src/js/Content/Features/Community/ProfileActivity/FReplaceCommunityHubLinks.js
@@ -14,10 +14,15 @@ export default class FReplaceCommunityHubLinks extends CallbackFeature {
     callback(parent = document) {
 
         // Don't replace user-provided links i.e. links in announcements/comments
-        const nodes = parent.querySelectorAll(".blotter_block a:not(.bb_link)");
+        const nodes = parent.querySelectorAll(".blotter_block a[href]:not(.bb_link)");
 
         for (const node of nodes) {
-            if (!node.hasAttribute("href")) { continue; }
+
+            // https://github.com/IsThereAnyDeal/AugmentedSteam/issues/1368
+            if (node.parentElement.classList.contains("blotter_group_announcement_headline")) {
+                continue;
+            }
+
             node.href = node.href.replace(/steamcommunity\.com\/(?:app|games)/, "store.steampowered.com/app");
         }
     }


### PR DESCRIPTION
Fixes #1368. Also simplify filtering links to highlight, and avoid processing "fake" links (those without the `href` attribute).