### PR TITLE
Fix error if favorited emoticon is no longer accessible

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -2295,6 +2295,10 @@ label.es_dlc_label > input:checked::after {
   max-height: none;
   display: flex;
 }
+.es_emoticons_content .no-access {
+  cursor: help;
+  opacity: 0.4;
+}
 #es_fav_remove {
   width: 10%;
   background-image: url(https://steamcommunity-a.akamaihd.net/economy/emoticon/remove);

--- a/src/js/Content/Modules/Community/CommentHandler.js
+++ b/src/js/Content/Modules/Community/CommentHandler.js
@@ -126,8 +126,15 @@ export class CommentHandler {
     }
 
     static _clickFavEmoticon(ev, emoticonPopup) {
-        const name = ev.target.closest(".emoticon_option").dataset.emoticon;
-        const noFav = emoticonPopup.querySelector(`[data-emoticon=${name}]:not(.es_fav)`);
+        const node = ev.target.closest(".emoticon_option");
+        const noFav = emoticonPopup.querySelector(`[data-emoticon=${node.dataset.emoticon}]:not(.es_fav)`);
+        if (!noFav) {
+            // The user doesn't have access to this emoticon
+            ev.stopPropagation();
+            node.classList.add("no-access");
+            node.querySelector("img").title = Localization.str.fav_emoticons_no_access;
+            return;
+        }
         noFav.click();
     }
 

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -47,6 +47,7 @@
     "email": "E-mail",
     "contact": "Contact",
     "fav_emoticons_dragging": "Drag emoticons here to favorite them",
+    "fav_emoticons_no_access": "You don't have access to this emoticon",
     "post_history": "View post history",
     "add_nickname": "Add Nickname",
     "total_size": "Total Size",


### PR DESCRIPTION
Can happen after an emoticon is listed on the market for example. Since this doesn't happen often, I think dimming the icon and adding a tooltip explaining should be enough?