### PR TITLE
Fix error when clicking on the "show all x comments" button under "uploaded a screenshot" type activity

### DIFF
--- a/src/js/Content/Features/Community/ProfileActivity/CProfileActivity.js
+++ b/src/js/Content/Features/Community/ProfileActivity/CProfileActivity.js
@@ -6,6 +6,7 @@ import FHighlightFriendsActivity from "./FHighlightFriendsActivity";
 import FAchievementLink from "./FAchievementLink";
 import FReplaceCommunityHubLinks from "./FReplaceCommunityHubLinks";
 import FToggleComments from "./FToggleComments";
+import {Page} from "../../Page";
 
 export class CProfileActivity extends CCommunityBase {
 
@@ -21,6 +22,20 @@ export class CProfileActivity extends CCommunityBase {
         FEarlyAccess.show(document.querySelectorAll(".blotter_gamepurchase_logo, .gameLogoHolder_default"));
 
         this._registerObserver();
+
+        // Fix undefined function when clicking on the "show all x comments" button under "uploaded a screenshot" type activity
+        Page.runInPageContext(() => {
+            /* eslint-disable no-undef, new-cap, camelcase */
+            if (typeof Blotter_ShowLargeScreenshot !== "function") {
+
+                Blotter_ShowLargeScreenshot = function(galleryid, showComments) {
+                    const gallery = g_BlotterGalleries[galleryid];
+                    const ss = gallery.shots[gallery.m_screenshotActive];
+                    ShowModalContent(`${ss.m_modalContentLink}&insideModal=1&showComments=${showComments}`, ss.m_modalContentLinkText, ss.m_modalContentLink, true);
+                };
+            }
+            /* eslint-enable no-undef, new-cap, camelcase */
+        });
     }
 
     _registerObserver() {


### PR DESCRIPTION
Restored the original code for `Blotter_ShowLargeScreenshot` found on one of the diffs from https://github.com/SteamDatabase/SteamTracking/blame/master/steamcommunity.com/public/javascript/blotter_functions.js