### PR TITLE
Loosen the match pattern for the points shop

### DIFF
--- a/config/manifests/manifest_common.json
+++ b/config/manifests/manifest_common.json
@@ -98,7 +98,7 @@
       "js": "js/store/agecheck.js"
     },
     {
-      "matches": "*://*.steampowered.com/points/shop[/*]",
+      "matches": "*://*.steampowered.com/points[/*]",
       "js": "js/store/points_shop.js"
     },
     {
@@ -128,7 +128,7 @@
         "*://*.steampowered.com/sub/*",
         "*://*.steampowered.com/app/*",
         "*://*.steampowered.com/agecheck/*",
-        "*://*.steampowered.com/points/shop[/*]"
+        "*://*.steampowered.com/points[/*]"
       ],
       "js": "js/store/default.js"
     },


### PR DESCRIPTION
This fixes points shop features not loading when clicking the corresponding link on the store nav bar, where the URL looks like `https://store.steampowered.com/points/?snr=` for whatever reason.