### PR TITLE
Fix website links without a protocol

### DIFF
--- a/src/js/Content/Features/Store/App/FSupportInfo.js
+++ b/src/js/Content/Features/Store/App/FSupportInfo.js
@@ -33,15 +33,16 @@ export default class FSupportInfo extends Feature {
             LocalStorage.set("support_info", cache);
         }
 
-        return this._supportInfo.url || this._supportInfo.email;
+        return Boolean(this._supportInfo.url || this._supportInfo.email);
     }
 
     apply() {
 
-        const {url, email} = this._supportInfo;
+        let {url, email} = this._supportInfo;
         const links = [];
 
         if (url) {
+            url = /^https?:\/\//.test(url) ? url : `//${url}`;
             links.push(`<a href="${url}">${Localization.str.website}</a>`);
         }
 


### PR DESCRIPTION
Some devs forget to include the protocol in the link, e.g. https://store.steampowered.com/app/1290000/PowerWash_Simulator/, causing the link to break when inserted directly into a `href`.