### PR TITLE
Fix How Long to Beat links' texts

### DIFF
--- a/src/js/Content/Features/Store/App/FHowLongToBeat.js
+++ b/src/js/Content/Features/Store/App/FHowLongToBeat.js
@@ -44,8 +44,8 @@ export default class FHowLongToBeat extends Feature {
             }
 
             html += `</div>
-                    <a class="linkbar es_external_icon" href="${HTML.escape(data.url)}" target="_blank">${Localization.str.more_information}"></a>
-                    <a class="linkbar es_external_icon" href="${HTML.escape(data.submit_url)}" target="_blank">${Localization.str.hltb.submit}"></a>`;
+                    <a class="linkbar es_external_icon" href="${HTML.escape(data.url)}" target="_blank">${Localization.str.more_information}</a>
+                    <a class="linkbar es_external_icon" href="${HTML.escape(data.submit_url)}" target="_blank">${Localization.str.hltb.submit}</a>`;
 
             // html += `<a class="linkbar es_external_icon" href="${suggestUrl}" id="es_hltb_suggest">${Localization.str.hltb.wrong} ${Localization.str.hltb.help}</a>`;
         } else {


### PR DESCRIPTION
Fixes a typo on "More Information" and "Submit Your Time" links' texts, where a `">` is shown in the end.

![How Long to Beat texts](https://user-images.githubusercontent.com/68337317/158088177-8b82b56f-4b69-4e13-ba70-d7bbb582e7dd.png)
