### PR TITLE
Make Steam Spy more localizable

### DIFF
--- a/src/js/Content/Features/Store/App/FSteamSpy.js
+++ b/src/js/Content/Features/Store/App/FSteamSpy.js
@@ -45,15 +45,15 @@ export default class FSteamSpy extends Feature {
         const result = [];
 
         const days = Math.trunc(_value / 1440);
-        if (days > 0) { result.push(`${days}d`); }
+        if (days > 0) { result.push(`${days}${Localization.str.spy.playtime_unit_day}`); }
         _value -= days * 1440;
 
         const hours = Math.trunc(_value / 60);
-        result.push(`${hours}h`);
+        result.push(`${hours}${Localization.str.spy.playtime_unit_hour}`);
         _value -= hours * 60;
 
         const minutes = _value;
-        result.push(`${minutes}m`);
+        result.push(`${minutes}${Localization.str.spy.playtime_unit_minute}`);
 
         return result.join(" ");
     }

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -421,6 +421,9 @@
         "average_playtime": "Average playtime",
         "average_playtime_2weeks": "Average playtime in the last two weeks",
         "formatted_time": "__hours__ hours, __minutes__ minutes"
+        "playtime_unit_day": "d"
+        "playtime_unit_hour": "h"
+        "playtime_unit_minute": "m"
     },
     "options": {
         "settings_mngmt": {

--- a/src/localization/ru.json
+++ b/src/localization/ru.json
@@ -19,7 +19,7 @@
     "oneclickgoo": "Превратить в самоцветы одной кнопкой",
     "view_in_library": "Открыть в библиотеке",
     "support": "Поддержка",
-    "email": "E-mail",
+    "email": "Эл. почта",
     "contact": "Связаться",
     "fav_emoticons_dragging": "Перетащите сюда смайлики, чтобы добавить в избранное",
     "post_history": "Показать историю сообщений",
@@ -376,6 +376,9 @@
         "average_playtime": "Средняя продолжительность",
         "average_playtime_2weeks": "Средняя продолжительность игры за последние две недели",
         "formatted_time": "__hours__ часов, __minutes__ минут"
+        "playtime_unit_day": "д"
+        "playtime_unit_hour": "ч"
+        "playtime_unit_minute": "м"
     },
     "options": {
         "community_default_tab": "Вкладка по умолчанию на главной странице Сообщества",


### PR DESCRIPTION
Added **playtime_unit_day**, **playtime_unit_hour** and **playtime_unit_minute** strings for _FSteamSpy.js_.
Localized those strings for russian and changed translation of email string.