### PR TITLE
Add feature to show confirmation when deleting comments

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -332,6 +332,7 @@
                     <div data-dynamic="steamcardexchange"></div>
                     <div data-dynamic="wlbuttoncommunityapp"></div>
                     <div data-dynamic="removeguideslanguagefilter"></div>
+                    <div data-dynamic="confirmdeletecomment"></div>
                 </div>
             </div>
         </div>

--- a/src/js/Content/Features/Community/CCommunityBase.js
+++ b/src/js/Content/Features/Community/CCommunityBase.js
@@ -1,5 +1,6 @@
 import {Context, ContextType} from "../../modulesContent";
 import FHideTrademarks from "../Common/FHideTrademarks";
+import FConfirmDeleteComment from "./FConfirmDeleteComment";
 
 export class CCommunityBase extends Context {
 
@@ -7,6 +8,7 @@ export class CCommunityBase extends Context {
 
         features.push(
             FHideTrademarks,
+            FConfirmDeleteComment,
         );
 
         super(type, features);

--- a/src/js/Content/Features/Community/FConfirmDeleteComment.js
+++ b/src/js/Content/Features/Community/FConfirmDeleteComment.js
@@ -1,0 +1,61 @@
+import {Localization, SyncedStorage} from "../../../modulesCore";
+import {Feature, Messenger, User} from "../../modulesContent";
+import {Page} from "../Page";
+
+export default class FConfirmDeleteComment extends Feature {
+
+    checkPrerequisites() {
+        return User.isSignedIn && SyncedStorage.get("confirmdeletecomment");
+    }
+
+    apply() {
+
+        Messenger.addMessageListener("setOption", value => SyncedStorage.set("confirmdeletecomment", value));
+
+        Page.runInPageContext((promptStr, labelStr) => {
+
+            // https://github.com/SteamDatabase/SteamTracking/blob/18d1c0eed3dcedc81656e3d278b3896253cc5b84/steamcommunity.com/public/javascript/global.js#L2465
+            const oldDeleteComment = CCommentThread.DeleteComment; // eslint-disable-line no-undef
+
+            CCommentThread.DeleteComment = function(id, gidcomment) { // eslint-disable-line no-undef
+
+                /**
+                 * Forum topics have special handling and show a prompt already
+                 * https://github.com/SteamDatabase/SteamTracking/blob/18d1c0eed3dcedc81656e3d278b3896253cc5b84/steamcommunity.com/public/javascript/forums.js#L1347
+                 */
+                if (id.startsWith("ForumTopic")) {
+                    oldDeleteComment.call(this, id, gidcomment);
+                    return;
+                }
+
+                const modal = window.SteamFacade.showConfirmDialog(
+                    "Augmented Steam",
+                    `${promptStr}<br><br>
+                    <label><input type="checkbox">${labelStr}</label>`
+                );
+
+                let checked = false;
+
+                document.querySelector(".newmodal input[type=checkbox]").addEventListener("change", e => {
+                    checked = e.currentTarget.checked;
+                    window.Messenger.postMessage("setOption", !checked);
+                });
+
+                // Restore old method if don't show is checked, so the prompt is not shown when deleting more comments on the same page
+                modal.always(() => {
+                    if (checked) {
+                        CCommentThread.DeleteComment = oldDeleteComment; // eslint-disable-line no-undef
+                    }
+                });
+
+                modal.done(() => {
+                    oldDeleteComment.call(this, id, gidcomment);
+                });
+            };
+        },
+        [
+            Localization.str.delete_comment_prompt,
+            Localization.str.update.dont_show
+        ]);
+    }
+}

--- a/src/js/Core/Storage/SyncedStorage.js
+++ b/src/js/Core/Storage/SyncedStorage.js
@@ -184,6 +184,7 @@ SyncedStorage.defaults = Object.freeze({
     "spamcommentregex": "[\\u2500-\\u25FF]",
     "wlbuttoncommunityapp": true,
     "removeguideslanguagefilter": false,
+    "confirmdeletecomment": true,
     "disablelinkfilter": false,
     "sortfriendsby": "default_ASC",
     "sortreviewsby": "default_ASC",

--- a/src/js/Options/Modules/Data/OptionsSetup.js
+++ b/src/js/Options/Modules/Data/OptionsSetup.js
@@ -194,4 +194,5 @@ export default {
     "steamcardexchange": "options.steamcardexchange",
     "wlbuttoncommunityapp": "options.wlbuttoncommunityapp",
     "removeguideslanguagefilter": "options.removeguideslanguagefilter",
+    "confirmdeletecomment": "options.confirmdeletecomment",
 };

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -1,4 +1,5 @@
 {
+    "delete_comment_prompt": "Are you sure you want to delete this comment?",
     "download_demo_header": "Download __gamename__ Demo",
     "feature_hint": {
         "desc": "Would you like to enable the following feature?",
@@ -473,6 +474,7 @@
         "show_package_info": "Show \"Package info\" button for all packages",
         "wlbuttoncommunityapp": "Show \"Add to Wishlist\" button on community hubs",
         "removeguideslanguagefilter": "Don't automatically filter guides by user language",
+        "confirmdeletecomment": "Show confirmation when deleting comments",
         "disablelinkfilter": "Disable confirmation when accessing external sites",
         "regional_price_on": "Show regional price comparison",
         "friends_own": "Items your friends own",


### PR DESCRIPTION
Closes #1166.

Following the comments in the issue, this feature is enabled by default with a handy checkbox to disable if desired. Works on comments under profiles, UGCs, etc. and is no-op for forum topics which have the native prompt. Though it  doesn't work if the item is opened in an iframe.