### PR TITLE
Rework Wishlist stats display

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -506,6 +506,36 @@ img.astats_icon {
 }
 
 /***************************************
+ * Wishlist and Games page stats
+ **************************************/
+#esi-wishlist-stats-content,
+#esi-games-stats-content {
+  display: flex;
+  padding: 25px;
+  overflow: hidden;
+  justify-content: space-evenly;
+  align-items: center;
+  font-size: 1.6em;
+  text-align: center;
+}
+.esi-stat {
+  display: flex;
+  flex-direction: column;
+}
+.esi-stat span {
+  font-size: 1.8em;
+  font-weight: 300;
+}
+#esi-wishlist-stats-content .esi-stat {
+  color: #222d3d;
+  font-weight: bold;
+}
+#esi-wishlist-stats,
+#esi-wishlist-stats-content .esi-stat span {
+  color: white;
+}
+
+/***************************************
  * Game Cards page
  **************************************/
 .es_card_search {
@@ -2224,35 +2254,6 @@ label.es_dlc_label > input:checked::after {
   margin-top: 32px;
 }
 
-#esi-wishlist-chart-content,
-#esi-collection-chart-content {
-  display: flex;
-  padding: 25px;
-  overflow: hidden;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 1.6em;
-  text-align: center;
-}
-#esi-wishlist-chart-content span {
-  flex-grow: 2;
-}
-#esi-wishlist-chart-content a,
-#esi-collection-chart-content a {
-  cursor: pointer;
-  flex-grow: 2;
-}
-
-.esi-wishlist-stat,
-.esi-collection-stat {
-  display: flex;
-  flex-direction: column;
-}
-.esi-wishlist-stat span,
-.esi-collection-stat span {
-  font-size: 1.8em;
-  font-weight: 300;
-}
 
 #es_new_queue {
   width: 150px;

--- a/src/js/Content/Features/Community/Games/FGamesStats.js
+++ b/src/js/Content/Features/Community/Games/FGamesStats.js
@@ -1,5 +1,5 @@
-import {Feature} from "../../../Modules/Feature/Feature";
 import {HTML, HTMLParser, Localization, SyncedStorage} from "../../../../modulesCore";
+import {Feature} from "../../../Modules/Feature/Feature";
 
 export default class FGamesStats extends Feature {
 
@@ -29,11 +29,11 @@ export default class FGamesStats extends Feature {
         const totalTime = Localization.str.hours_short.replace("__hours__", time.toFixed(1));
 
         HTML.beforeBegin("#mainContents",
-            `<div id="esi-collection-chart-content">
-                <div class="esi-collection-stat"><span class="num">${totalTime}</span>${Localization.str.coll.total_time}</div>
-                <div class="esi-collection-stat"><span class="num">${countTotal}</span>${Localization.str.coll.in_collection}</div>
-                <div class="esi-collection-stat"><span class="num">${countPlayed}</span>${Localization.str.coll.played}</div>
-                <div class="esi-collection-stat"><span class="num">${countNeverPlayed}</span>${Localization.str.coll.never_played}</div>
+            `<div id="esi-games-stats-content">
+                <div class="esi-stat"><span>${totalTime}</span>${Localization.str.coll.total_time}</div>
+                <div class="esi-stat"><span>${countTotal}</span>${Localization.str.coll.in_collection}</div>
+                <div class="esi-stat"><span>${countPlayed}</span>${Localization.str.coll.played}</div>
+                <div class="esi-stat"><span>${countNeverPlayed}</span>${Localization.str.coll.never_played}</div>
             </div>`);
     }
 }

--- a/src/js/Content/Features/Store/Wishlist/FWishlistStats.js
+++ b/src/js/Content/Features/Store/Wishlist/FWishlistStats.js
@@ -37,12 +37,7 @@ export default class FWishlistStats extends Feature {
 
         // capture this event so it doesn't get default prevented
         document.body.addEventListener("click", ({target}) => {
-            if (
-                !statsBtn.classList.contains("hover")
-                || target.closest("#esi-wishlist-stats, #esi-wishlist-stats-content") !== null
-            ) {
-                return;
-            }
+            if (statsBtn.contains(target) || statsContent.contains(target)) { return; }
 
             statsBtn.classList.remove("hover");
             statsContent.classList.remove("hover");

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -737,6 +737,7 @@
         "default": "An unexpected error occurred.  Your product code has not been redeemed.  Please wait 30 minutes and try redeeming the code again."
     },
     "wl": {
+        "label": "stats",
         "total_price": "current value",
         "in_wishlist": "on wishlist",
         "on_sale": "on sale",


### PR DESCRIPTION
Change the Wishlist stats area to display in a hover element. This avoids the area taking up space in the wishlist container, changing its `offsetHeight` value and affecting how row dragging and scrolling behaves. Fixes #1037.

![螢幕擷取畫面 2022-05-25 210356](https://user-images.githubusercontent.com/54083835/170270712-50162884-a2e0-4318-832f-5a0f4f60e1da.jpg)

It's tempting to make this feature enabled by default and remove the option, but since it does takes up space and apparently there's an option for showing the "empty wishlist" button as well, I left it as-is for now.