### PR TITLE
Update wishlist remove endpoint

### DIFF
--- a/src/js/Content/Features/Store/Wishlist/FEmptyWishlist.js
+++ b/src/js/Content/Features/Store/Wishlist/FEmptyWishlist.js
@@ -42,6 +42,7 @@ export default class FEmptyWishlist extends Feature {
 
             let cur = 1;
             const textNode = document.querySelector(".waiting_dialog_throbber").nextSibling;
+            const url = "https://store.steampowered.com/api/removefromwishlist";
 
             for (const {appid} of wishlistData) {
                 textNode.textContent = Localization.str.empty_wishlist.removing
@@ -52,7 +53,6 @@ export default class FEmptyWishlist extends Feature {
                 formData.append("sessionid", User.sessionId);
                 formData.append("appid", appid);
 
-                const url = `https://store.steampowered.com/wishlist/profiles/${User.steamId}/remove/`;
                 await RequestData.post(url, formData);
             }
 

--- a/src/js/Content/Features/Store/Wishlist/FOneClickRemoveFromWishlist.js
+++ b/src/js/Content/Features/Store/Wishlist/FOneClickRemoveFromWishlist.js
@@ -23,20 +23,11 @@ export default class FOneClickRemoveFromWishlist extends CallbackFeature {
             // eslint-disable-next-line no-loop-func
             newDeleteNode.addEventListener("click", () => {
 
-                /*
-                 * Modified version of fnRemoveFromWishlist from wishlist.js
-                 * https://github.com/SteamDatabase/SteamTracking/blob/ca5145acba077bee42de2593f6b17a6ed045b5f6/store.steampowered.com/public/javascript/wishlist.js#L173
-                 */
+                // https://github.com/SteamDatabase/SteamTracking/blob/161d053dc7bd782333584196d97bce5f7509d640/store.steampowered.com/public/javascript/wishlist.js#L158
                 Page.runInPageContext(appid => {
-
                     const f = window.SteamFacade;
 
-                    f.jqPost(`${f.global("g_strWishlistBaseURL")}remove/`, {
-                        appid,
-                        "sessionid": f.global("g_sessionID")
-                    });
-
-                    f.dynamicStoreInvalidateCache();
+                    f.removeFromWishlist(appid);
 
                     f.jq("#wishlist_ctn").removeClass("sorting");
 

--- a/src/js/Content/Modules/SteamFacade.js
+++ b/src/js/Content/Modules/SteamFacade.js
@@ -64,6 +64,11 @@ class SteamFacade {
         return UpdatePlaytimeFilterValues(hourMin, hourMax);
     }
 
+    // @param appid required, rest is optional
+    static removeFromWishlist(appid, divToHide, divToShowSuccess, divToShowError, navref, divToHide2) {
+        return RemoveFromWishlist(appid, divToHide, divToShowSuccess, divToShowError, navref, divToHide2);
+    }
+
     // events
 
     static bindAutoFlyoutEvents() {


### PR DESCRIPTION
A few months back Steam changed the removal endpoint used on wishlists to match the one used on app pages. We should follow suit.