### PR TITLE
Update hosts for Steam assets

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -74,7 +74,7 @@
 
 /**
  * Customize button on storefront and app pages
- * Taken from: https://store.akamai.steamstatic.com/public/css/v6/home.css
+ * Taken from: https://store.cloudflare.steamstatic.com/public/css/v6/home.css
  */
 #es_customize_btn {
   text-align: left;
@@ -141,7 +141,7 @@
   display: inline-block;
   width: 14px;
   height: 14px;
-  background-image: url('https://store.akamai.steamstatic.com/public/images/v6/customize_checkboxes.png');
+  background-image: url('https://store.cloudflare.steamstatic.com/public/images/v6/customize_checkboxes.png');
   background-position: 0px 0px;
 }
 #es_customize_btn .home_viewsettings_checkbox.checked {
@@ -658,7 +658,7 @@ img.astats_icon {
   display: inline;
 }
 
-/** Flyout menus, taken from https://store.akamai.steamstatic.com/public/css/v6/store.css */
+/** Flyout menus, taken from https://store.cloudflare.steamstatic.com/public/css/v6/store.css */
 .as_flyout_menus .store_nav {
   display: inline;
   float: none;
@@ -693,7 +693,7 @@ img.astats_icon {
   height: 12px;
   padding: 0;
   display: inline-block;
-  background-image: url('https://store.akamai.steamstatic.com/public/images/v6/btn_arrow_down_padded.png');
+  background-image: url('https://store.cloudflare.steamstatic.com/public/images/v6/btn_arrow_down_padded.png');
   background-position: center;
   background-repeat: no-repeat;
   cursor: pointer;
@@ -701,7 +701,7 @@ img.astats_icon {
 }
 .as_flyout_menus .store_nav .tab:hover > span.pulldown > span,
 .as_flyout_menus .store_nav .tab.focus > span.pulldown > span {
-  background-image: url('https://store.akamai.steamstatic.com/public/images/v6/btn_arrow_down_padded_white.png');
+  background-image: url('https://store.cloudflare.steamstatic.com/public/images/v6/btn_arrow_down_padded_white.png');
 }
 .as_flyout_menus .popup_block_new .popup_body {
   border: none;
@@ -1007,7 +1007,7 @@ img.astats_icon {
 .es-achieveBar-store {
   float: right;
 }
-/* Taken from: https://community.akamai.steamstatic.com/public/css/skin_1/playerstats_generic.css */
+/* Taken from: https://community.cloudflare.steamstatic.com/public/css/skin_1/playerstats_generic.css */
 .es-achieveBar-store .achieveBar {
   background: #3a3a3a;
   padding: 1px;
@@ -1925,7 +1925,7 @@ img.astats_icon {
   white-space: nowrap;
 }
 .es-itad-hover__arrow {
-  background-image: url(https://community.akamai.steamstatic.com/public/shared/images/popups/hover_arrow_both.gif);
+  background-image: url(https://community.cloudflare.steamstatic.com/public/shared/images/popups/hover_arrow_both.gif);
   background-repeat: no-repeat;
   position: absolute;
   top: 0;
@@ -2301,7 +2301,7 @@ label.es_dlc_label > input:checked::after {
 }
 #es_fav_remove {
   width: 10%;
-  background-image: url(https://community.akamai.steamstatic.com/economy/emoticon/remove);
+  background-image: url(https://community.cloudflare.steamstatic.com/economy/emoticon/remove);
   background-repeat: no-repeat;
   background-position: center;
 }
@@ -2337,7 +2337,7 @@ label.es_dlc_label > input:checked::after {
  * Global Steam Client button
  **************************************/
 .header_installsteam_btn_content.es_steamclient_btn {
-  background-image: url('https://store.akamai.steamstatic.com/public/images/v6/icon_platform_linux.png');
+  background-image: url('https://store.cloudflare.steamstatic.com/public/images/v6/icon_platform_linux.png');
   background-position: 5px;
   padding-left: 28px;
 }
@@ -2901,7 +2901,7 @@ label.es_dlc_label > input:checked::after {
   top: 0;
   bottom: 0;
   width: 20px;
-  background: url(https://store.akamai.steamstatic.com/public/images/v6/ico/ico_arrow_dn_for_select.png) no-repeat left center;
+  background: url(https://store.cloudflare.steamstatic.com/public/images/v6/ico/ico_arrow_dn_for_select.png) no-repeat left center;
   content: '';
 }
 .es-dropdown {

--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -74,7 +74,7 @@
 
 /**
  * Customize button on storefront and app pages
- * Taken from: https://steamstore-a.akamaihd.net/public/css/v6/home.css
+ * Taken from: https://store.akamai.steamstatic.com/public/css/v6/home.css
  */
 #es_customize_btn {
   text-align: left;
@@ -141,7 +141,7 @@
   display: inline-block;
   width: 14px;
   height: 14px;
-  background-image: url('https://steamstore-a.akamaihd.net/public/images/v6/customize_checkboxes.png');
+  background-image: url('https://store.akamai.steamstatic.com/public/images/v6/customize_checkboxes.png');
   background-position: 0px 0px;
 }
 #es_customize_btn .home_viewsettings_checkbox.checked {
@@ -658,7 +658,7 @@ img.astats_icon {
   display: inline;
 }
 
-/** Flyout menus, taken from https://steamstore-a.akamaihd.net/public/css/v6/store.css */
+/** Flyout menus, taken from https://store.akamai.steamstatic.com/public/css/v6/store.css */
 .as_flyout_menus .store_nav {
   display: inline;
   float: none;
@@ -693,7 +693,7 @@ img.astats_icon {
   height: 12px;
   padding: 0;
   display: inline-block;
-  background-image: url('https://steamstore-a.akamaihd.net/public/images/v6/btn_arrow_down_padded.png');
+  background-image: url('https://store.akamai.steamstatic.com/public/images/v6/btn_arrow_down_padded.png');
   background-position: center;
   background-repeat: no-repeat;
   cursor: pointer;
@@ -701,7 +701,7 @@ img.astats_icon {
 }
 .as_flyout_menus .store_nav .tab:hover > span.pulldown > span,
 .as_flyout_menus .store_nav .tab.focus > span.pulldown > span {
-  background-image: url('https://steamstore-a.akamaihd.net/public/images/v6/btn_arrow_down_padded_white.png');
+  background-image: url('https://store.akamai.steamstatic.com/public/images/v6/btn_arrow_down_padded_white.png');
 }
 .as_flyout_menus .popup_block_new .popup_body {
   border: none;
@@ -1007,7 +1007,7 @@ img.astats_icon {
 .es-achieveBar-store {
   float: right;
 }
-/* Taken from: https://steamcommunity-a.akamaihd.net/public/css/skin_1/playerstats_generic.css */
+/* Taken from: https://community.akamai.steamstatic.com/public/css/skin_1/playerstats_generic.css */
 .es-achieveBar-store .achieveBar {
   background: #3a3a3a;
   padding: 1px;
@@ -1925,7 +1925,7 @@ img.astats_icon {
   white-space: nowrap;
 }
 .es-itad-hover__arrow {
-  background-image: url(https://steamcommunity-a.akamaihd.net/public/shared/images/popups/hover_arrow_both.gif);
+  background-image: url(https://community.akamai.steamstatic.com/public/shared/images/popups/hover_arrow_both.gif);
   background-repeat: no-repeat;
   position: absolute;
   top: 0;
@@ -2301,7 +2301,7 @@ label.es_dlc_label > input:checked::after {
 }
 #es_fav_remove {
   width: 10%;
-  background-image: url(https://steamcommunity-a.akamaihd.net/economy/emoticon/remove);
+  background-image: url(https://community.akamai.steamstatic.com/economy/emoticon/remove);
   background-repeat: no-repeat;
   background-position: center;
 }
@@ -2337,7 +2337,7 @@ label.es_dlc_label > input:checked::after {
  * Global Steam Client button
  **************************************/
 .header_installsteam_btn_content.es_steamclient_btn {
-  background-image: url('https://steamstore-a.akamaihd.net/public/images/v6/icon_platform_linux.png');
+  background-image: url('https://store.akamai.steamstatic.com/public/images/v6/icon_platform_linux.png');
   background-position: 5px;
   padding-left: 28px;
 }
@@ -2901,7 +2901,7 @@ label.es_dlc_label > input:checked::after {
   top: 0;
   bottom: 0;
   width: 20px;
-  background: url(https://steamstore-a.akamaihd.net/public/images/v6/ico/ico_arrow_dn_for_select.png) no-repeat left center;
+  background: url(https://store.akamai.steamstatic.com/public/images/v6/ico/ico_arrow_dn_for_select.png) no-repeat left center;
   content: '';
 }
 .es-dropdown {

--- a/src/js/Content/Features/Community/App/FCommunityAppPageWishlist.js
+++ b/src/js/Content/Features/Community/App/FCommunityAppPageWishlist.js
@@ -22,15 +22,15 @@ export default class FCommunityAppPageWishlist extends Feature {
             // First whitespace intended, separates buttons
             ` <a id="es_wishlist_add" class="btnv6_blue_hoverfade btn_medium" style="${wishlisted ? "display: none;" : ""}">
                 <span>
-                    <img class="es-loading-wl" src="//steamcommunity-a.akamaihd.net/public/images/login/throbber.gif" style="display: none;">
+                    <img class="es-loading-wl" src="//community.akamai.steamstatic.com/public/images/login/throbber.gif" style="display: none;">
                     ${Localization.str.add_to_wishlist}
                 </span>
             </a>
             <a id="es_wishlist_success" class="btnv6_blue_hoverfade btn_medium" style="${wishlisted ? "" : "display: none;"}">
                 <span>
                     <img class="es-remove-wl" src="${ExtensionResources.getURL("img/remove.png")}" style="display: none;">
-                    <img class="es-loading-wl" src="//steamcommunity-a.akamaihd.net/public/images/login/throbber.gif" style="display: none;">
-                    <img class="es-in-wl" src="//steamstore-a.akamaihd.net/public/images/v6/ico/ico_selected.png" border="0">
+                    <img class="es-loading-wl" src="//community.akamai.steamstatic.com/public/images/login/throbber.gif" style="display: none;">
+                    <img class="es-in-wl" src="//store.akamai.steamstatic.com/public/images/v6/ico/ico_selected.png" border="0">
                     ${Localization.str.on_wishlist}
                 </span>
             </a>

--- a/src/js/Content/Features/Community/App/FCommunityAppPageWishlist.js
+++ b/src/js/Content/Features/Community/App/FCommunityAppPageWishlist.js
@@ -22,15 +22,15 @@ export default class FCommunityAppPageWishlist extends Feature {
             // First whitespace intended, separates buttons
             ` <a id="es_wishlist_add" class="btnv6_blue_hoverfade btn_medium" style="${wishlisted ? "display: none;" : ""}">
                 <span>
-                    <img class="es-loading-wl" src="//community.akamai.steamstatic.com/public/images/login/throbber.gif" style="display: none;">
+                    <img class="es-loading-wl" src="//community.cloudflare.steamstatic.com/public/images/login/throbber.gif" style="display: none;">
                     ${Localization.str.add_to_wishlist}
                 </span>
             </a>
             <a id="es_wishlist_success" class="btnv6_blue_hoverfade btn_medium" style="${wishlisted ? "" : "display: none;"}">
                 <span>
                     <img class="es-remove-wl" src="${ExtensionResources.getURL("img/remove.png")}" style="display: none;">
-                    <img class="es-loading-wl" src="//community.akamai.steamstatic.com/public/images/login/throbber.gif" style="display: none;">
-                    <img class="es-in-wl" src="//store.akamai.steamstatic.com/public/images/v6/ico/ico_selected.png" border="0">
+                    <img class="es-loading-wl" src="//community.cloudflare.steamstatic.com/public/images/login/throbber.gif" style="display: none;">
+                    <img class="es-in-wl" src="//store.cloudflare.steamstatic.com/public/images/v6/ico/ico_selected.png" border="0">
                     ${Localization.str.on_wishlist}
                 </span>
             </a>

--- a/src/js/Content/Features/Community/FFixAppImageNotFound.js
+++ b/src/js/Content/Features/Community/FFixAppImageNotFound.js
@@ -10,7 +10,7 @@ export default class FFixAppImageNotFound extends Feature {
             const appid = GameId.getAppid(node.parentNode.href);
             if (!appid) { return; }
 
-            const src = `https://cdn.akamai.steamstatic.com/steam/apps/${appid}/capsule_184x69.jpg`;
+            const src = `https://cdn.cloudflare.steamstatic.com/steam/apps/${appid}/capsule_184x69.jpg`;
 
             const testImg = document.createElement("img");
             testImg.src = src;

--- a/src/js/Content/Features/Community/GroupHome/FFriendsInviteButton.js
+++ b/src/js/Content/Features/Community/GroupHome/FFriendsInviteButton.js
@@ -11,7 +11,7 @@ export default class FFriendsInviteButton extends Feature {
         HTML.afterEnd("#join_group_form",
             `<div class="grouppage_join_area">
                 <a class="btn_blue_white_innerfade btn_medium" href="https://steamcommunity.com/my/friends/?invitegid=${this.context.groupId}">
-                    <span><img src="//steamcommunity-a.akamaihd.net/public/images/groups/icon_invitefriends.png">&nbsp; ${Localization.str.invite_friends}</span>
+                    <span><img src="//community.akamai.steamstatic.com/public/images/groups/icon_invitefriends.png">&nbsp; ${Localization.str.invite_friends}</span>
                 </a>
             </div>`);
     }

--- a/src/js/Content/Features/Community/GroupHome/FFriendsInviteButton.js
+++ b/src/js/Content/Features/Community/GroupHome/FFriendsInviteButton.js
@@ -11,7 +11,7 @@ export default class FFriendsInviteButton extends Feature {
         HTML.afterEnd("#join_group_form",
             `<div class="grouppage_join_area">
                 <a class="btn_blue_white_innerfade btn_medium" href="https://steamcommunity.com/my/friends/?invitegid=${this.context.groupId}">
-                    <span><img src="//community.akamai.steamstatic.com/public/images/groups/icon_invitefriends.png">&nbsp; ${Localization.str.invite_friends}</span>
+                    <span><img src="//community.cloudflare.steamstatic.com/public/images/groups/icon_invitefriends.png">&nbsp; ${Localization.str.invite_friends}</span>
                 </a>
             </div>`);
     }

--- a/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
+++ b/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
@@ -115,7 +115,7 @@ export default class FQuickSellOptions extends CallbackFeature {
 
             HTML.inner(marketActions.querySelector("div"),
                 `<div class="es_loading" style="min-height: 66px;">
-                    <img src="//community.akamai.steamstatic.com/public/images/login/throbber.gif">
+                    <img src="//community.cloudflare.steamstatic.com/public/images/login/throbber.gif">
                     <span>${Localization.str.selling}</span>
                 </div>`);
 

--- a/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
+++ b/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
@@ -115,7 +115,7 @@ export default class FQuickSellOptions extends CallbackFeature {
 
             HTML.inner(marketActions.querySelector("div"),
                 `<div class="es_loading" style="min-height: 66px;">
-                    <img src="//steamcommunity-a.akamaihd.net/public/images/login/throbber.gif">
+                    <img src="//community.akamai.steamstatic.com/public/images/login/throbber.gif">
                     <span>${Localization.str.selling}</span>
                 </div>`);
 

--- a/src/js/Content/Features/Community/Inventory/FShowMarketOverview.js
+++ b/src/js/Content/Features/Community/Inventory/FShowMarketOverview.js
@@ -112,7 +112,7 @@ export default class FShowMarketOverview extends CallbackFeature {
         if (!thisItem.dataset.lowestPrice) {
             if (firstDiv.querySelector("img.es_loading") !== null) { return; }
 
-            HTML.inner(firstDiv, '<img class="es_loading" src="//community.akamai.steamstatic.com/public/images/login/throbber.gif">');
+            HTML.inner(firstDiv, '<img class="es_loading" src="//community.cloudflare.steamstatic.com/public/images/login/throbber.gif">');
 
             thisItem.dataset.lowestPrice = "nodata";
             thisItem.dataset.soldVolume = "nodata";

--- a/src/js/Content/Features/Community/Inventory/FShowMarketOverview.js
+++ b/src/js/Content/Features/Community/Inventory/FShowMarketOverview.js
@@ -112,7 +112,7 @@ export default class FShowMarketOverview extends CallbackFeature {
         if (!thisItem.dataset.lowestPrice) {
             if (firstDiv.querySelector("img.es_loading") !== null) { return; }
 
-            HTML.inner(firstDiv, '<img class="es_loading" src="//steamcommunity-a.akamaihd.net/public/images/login/throbber.gif">');
+            HTML.inner(firstDiv, '<img class="es_loading" src="//community.akamai.steamstatic.com/public/images/login/throbber.gif">');
 
             thisItem.dataset.lowestPrice = "nodata";
             thisItem.dataset.soldVolume = "nodata";

--- a/src/js/Content/Features/Community/MarketHome/FMarketStats.js
+++ b/src/js/Content/Features/Community/MarketHome/FMarketStats.js
@@ -33,7 +33,7 @@ export default class FMarketStats extends Feature {
         const statusNode = document.getElementById("es_market_summary_status");
 
         HTML.inner(statusNode,
-            `<img id="es_market_summary_throbber" src="//steamcommunity-a.akamaihd.net/public/images/login/throbber.gif">
+            `<img id="es_market_summary_throbber" src="//community.akamai.steamstatic.com/public/images/login/throbber.gif">
             <span>
                 <span id="esi_market_stats_progress_description">${Localization.str.loading} </span>
                 <span id="esi_market_stats_progress"></span>

--- a/src/js/Content/Features/Community/MarketHome/FMarketStats.js
+++ b/src/js/Content/Features/Community/MarketHome/FMarketStats.js
@@ -33,7 +33,7 @@ export default class FMarketStats extends Feature {
         const statusNode = document.getElementById("es_market_summary_status");
 
         HTML.inner(statusNode,
-            `<img id="es_market_summary_throbber" src="//community.akamai.steamstatic.com/public/images/login/throbber.gif">
+            `<img id="es_market_summary_throbber" src="//community.cloudflare.steamstatic.com/public/images/login/throbber.gif">
             <span>
                 <span id="esi_market_stats_progress_description">${Localization.str.loading} </span>
                 <span id="esi_market_stats_progress"></span>

--- a/src/js/Content/Features/Community/ProfileEdit/FBackgroundSelection.js
+++ b/src/js/Content/Features/Community/ProfileEdit/FBackgroundSelection.js
@@ -184,7 +184,7 @@ export default class FBackgroundSelection extends Feature {
     _showBgFormLoading(node) {
         HTML.inner(node,
             `<div class="es_loading">
-                <img src="https://steamcommunity-a.akamaihd.net/public/images/login/throbber.gif">
+                <img src="//community.akamai.steamstatic.com/public/images/login/throbber.gif">
                 <span>${Localization.str.loading}</span>
             </div>`);
     }

--- a/src/js/Content/Features/Community/ProfileEdit/FBackgroundSelection.js
+++ b/src/js/Content/Features/Community/ProfileEdit/FBackgroundSelection.js
@@ -184,7 +184,7 @@ export default class FBackgroundSelection extends Feature {
     _showBgFormLoading(node) {
         HTML.inner(node,
             `<div class="es_loading">
-                <img src="//community.akamai.steamstatic.com/public/images/login/throbber.gif">
+                <img src="//community.cloudflare.steamstatic.com/public/images/login/throbber.gif">
                 <span>${Localization.str.loading}</span>
             </div>`);
     }

--- a/src/js/Content/Features/Community/ProfileHome/FChatDropdownOptions.js
+++ b/src/js/Content/Features/Community/ProfileHome/FChatDropdownOptions.js
@@ -17,16 +17,16 @@ export default class FChatDropdownOptions extends Feature {
 
         HTML.replace(sendButton,
             `<span class="btn_profile_action btn_medium" id="profile_chat_dropdown_link">
-                <span>${sendButton.textContent}<img src="//community.akamai.steamstatic.com/public/images/profile/profile_action_dropdown.png"></span>
+                <span>${sendButton.textContent}<img src="//community.cloudflare.steamstatic.com/public/images/profile/profile_action_dropdown.png"></span>
             </span>
             <div class="popup_block" id="profile_chat_dropdown">
                 <div class="popup_body popup_menu shadow_content">
                     <a id="btnWebChat" class="popup_menu_item">
-                        <img src="//community.akamai.steamstatic.com/public/images/skin_1/icon_btn_comment.png">
+                        <img src="//community.cloudflare.steamstatic.com/public/images/skin_1/icon_btn_comment.png">
                         &nbsp; ${Localization.str.web_browser_chat}
                     </a>
                     <a class="popup_menu_item" href="steam://friends/message/${friendSteamId}">
-                        <img src="//community.akamai.steamstatic.com/public/images/skin_1/icon_btn_comment.png">
+                        <img src="//community.cloudflare.steamstatic.com/public/images/skin_1/icon_btn_comment.png">
                         &nbsp; ${Localization.str.steam_client_chat}
                     </a>
                 </div>

--- a/src/js/Content/Features/Community/ProfileHome/FChatDropdownOptions.js
+++ b/src/js/Content/Features/Community/ProfileHome/FChatDropdownOptions.js
@@ -17,16 +17,16 @@ export default class FChatDropdownOptions extends Feature {
 
         HTML.replace(sendButton,
             `<span class="btn_profile_action btn_medium" id="profile_chat_dropdown_link">
-                <span>${sendButton.textContent}<img src="//steamcommunity-a.akamaihd.net/public/images/profile/profile_action_dropdown.png"></span>
+                <span>${sendButton.textContent}<img src="//community.akamai.steamstatic.com/public/images/profile/profile_action_dropdown.png"></span>
             </span>
             <div class="popup_block" id="profile_chat_dropdown">
                 <div class="popup_body popup_menu shadow_content">
                     <a id="btnWebChat" class="popup_menu_item">
-                        <img src="//steamcommunity-a.akamaihd.net/public/images/skin_1/icon_btn_comment.png">
+                        <img src="//community.akamai.steamstatic.com/public/images/skin_1/icon_btn_comment.png">
                         &nbsp; ${Localization.str.web_browser_chat}
                     </a>
                     <a class="popup_menu_item" href="steam://friends/message/${friendSteamId}">
-                        <img src="//steamcommunity-a.akamaihd.net/public/images/skin_1/icon_btn_comment.png">
+                        <img src="//community.akamai.steamstatic.com/public/images/skin_1/icon_btn_comment.png">
                         &nbsp; ${Localization.str.steam_client_chat}
                     </a>
                 </div>

--- a/src/js/Content/Features/Community/ProfileHome/FCustomBackground.js
+++ b/src/js/Content/Features/Community/ProfileHome/FCustomBackground.js
@@ -6,7 +6,7 @@ export default class FCustomBackground extends Feature {
     checkPrerequisites() {
         const prevHash = window.location.hash.match(/#previewBackground\/(\d+)\/([a-z0-9.]+)/i);
         if (prevHash) {
-            const src = `//cdn.akamai.steamstatic.com/steamcommunity/public/images/items/${prevHash[1]}/${prevHash[2]}`;
+            const src = `//cdn.cloudflare.steamstatic.com/steamcommunity/public/images/items/${prevHash[1]}/${prevHash[2]}`;
             this._setProfileBg(src);
 
             return false;

--- a/src/js/Content/Features/Community/ProfileHome/FCustomStyle.js
+++ b/src/js/Content/Features/Community/ProfileHome/FCustomStyle.js
@@ -35,7 +35,7 @@ export default class FCustomStyle extends Feature {
 
         switch (style) {
             case "winter2019": {
-                DOMHelper.insertStylesheet("//steamcommunity-a.akamaihd.net/public/css/promo/winter2019/goldenprofile.css");
+                DOMHelper.insertStylesheet("//community.akamai.steamstatic.com/public/css/promo/winter2019/goldenprofile.css");
 
                 const profilePageNode = document.querySelector(".no_header.profile_page");
                 profilePageNode.classList.add("golden_profile");
@@ -49,7 +49,7 @@ export default class FCustomStyle extends Feature {
                             <div class="w19_top"></div>
                             <div class="w19_pendulum">
                                 <div class="w19_strings"></div>
-                                <img src="//steamcdn-a.akamaihd.net/steamcommunity/public/assets/winter2019/goldenprofile/dangle_flake.png">
+                                <img src="//cdn.akamai.steamstatic.com/steamcommunity/public/assets/winter2019/goldenprofile/dangle_flake.png">
                             </div>
                         </div>
                         <div class="w19_side right">
@@ -58,7 +58,7 @@ export default class FCustomStyle extends Feature {
                             <div class="w19_top"></div>
                             <div class="w19_pendulum">
                                 <div class="w19_strings"></div>
-                                <img src="//steamcdn-a.akamaihd.net/steamcommunity/public/assets/winter2019/goldenprofile/dangle_flake.png">
+                                <img src="//cdn.akamai.steamstatic.com/steamcommunity/public/assets/winter2019/goldenprofile/dangle_flake.png">
                             </div>
                         </div>
                         <div class="snowflakes" aria-hidden="true">
@@ -83,7 +83,7 @@ export default class FCustomStyle extends Feature {
                 break;
             }
             case "goldenprofile2020": {
-                DOMHelper.insertStylesheet("//steamcommunity-a.akamaihd.net/public/css/promo/lny2020/goldenprofile.css");
+                DOMHelper.insertStylesheet("//community.akamai.steamstatic.com/public/css/promo/lny2020/goldenprofile.css");
 
                 const profilePageNode = document.querySelector(".no_header.profile_page");
                 profilePageNode.classList.add("golden_profile");
@@ -110,9 +110,9 @@ export default class FCustomStyle extends Feature {
 
                     HTML.afterBegin(profilePageNode,
                         `<div class="profile_animated_background">
-                            <video playsinline autoplay muted loop poster="//steamcdn-a.akamaihd.net/steamcommunity/public/images/items/1223590/daa4b34582ed6cab1327f247be8d03d92ae8aaaa.jpg">
-                                <source src="//steamcdn-a.akamaihd.net/steamcommunity/public/images/items/1223590/c146558951b46ade8d64ea8e787980f84d30ec46.webm" type="video/webm">
-                                <source src="//steamcdn-a.akamaihd.net/steamcommunity/public/images/items/1223590/b5c39efda3998e0d2e734e8b7385ecf705ce8cc5.mp4" type="video/mp4">
+                            <video playsinline autoplay muted loop poster="//cdn.akamai.steamstatic.com/steamcommunity/public/images/items/1223590/daa4b34582ed6cab1327f247be8d03d92ae8aaaa.jpg">
+                                <source src="//cdn.akamai.steamstatic.com/steamcommunity/public/images/items/1223590/c146558951b46ade8d64ea8e787980f84d30ec46.webm" type="video/webm">
+                                <source src="//cdn.akamai.steamstatic.com/steamcommunity/public/images/items/1223590/b5c39efda3998e0d2e734e8b7385ecf705ce8cc5.mp4" type="video/mp4">
                             </video>
                         </div>`);
 
@@ -124,7 +124,7 @@ export default class FCustomStyle extends Feature {
                 break;
             }
             case "goldenprofile": {
-                DOMHelper.insertStylesheet("//steamcommunity-a.akamaihd.net/public/css/promo/lny2019/goldenprofile.css");
+                DOMHelper.insertStylesheet("//community.akamai.steamstatic.com/public/css/promo/lny2019/goldenprofile.css");
 
                 const profilePageNode = document.querySelector(".no_header.profile_page");
                 profilePageNode.classList.add("golden_profile");
@@ -138,7 +138,7 @@ export default class FCustomStyle extends Feature {
                             <div class="lny_pig"></div>
                             <div class="lny_pendulum">
                                 <div class="lny_strings"></div>
-                                <img src="//steamcdn-a.akamaihd.net/steamcommunity/public/assets/lny2019/goldenprofile/test_lantern1.png">
+                                <img src="//cdn.akamai.steamstatic.com/steamcommunity/public/assets/lny2019/goldenprofile/test_lantern1.png">
                             </div>
                         </div>
                         <div class="lny_side right">
@@ -147,7 +147,7 @@ export default class FCustomStyle extends Feature {
                             <div class="lny_pig"></div>
                             <div class="lny_pendulum">
                                 <div class="lny_strings"></div>
-                                <img src="//steamcdn-a.akamaihd.net/steamcommunity/public/assets/lny2019/goldenprofile/test_lantern2.png">
+                                <img src="//cdn.akamai.steamstatic.com/steamcommunity/public/assets/lny2019/goldenprofile/test_lantern2.png">
                             </div>
                         </div>
                     </div>`);
@@ -162,7 +162,7 @@ export default class FCustomStyle extends Feature {
                 break;
             }
             case "holiday2014":
-                DOMHelper.insertStylesheet("//steamcommunity-a.akamaihd.net/public/css/skin_1/holidayprofile.css");
+                DOMHelper.insertStylesheet("//community.akamai.steamstatic.com/public/css/skin_1/holidayprofile.css");
 
                 HTML.beforeEnd(".profile_header_bg_texture", "<div class='holidayprofile_header_overlay'></div>");
                 document.querySelector(".no_header.profile_page").classList.add("holidayprofile");

--- a/src/js/Content/Features/Community/ProfileHome/FCustomStyle.js
+++ b/src/js/Content/Features/Community/ProfileHome/FCustomStyle.js
@@ -35,7 +35,7 @@ export default class FCustomStyle extends Feature {
 
         switch (style) {
             case "winter2019": {
-                DOMHelper.insertStylesheet("//community.akamai.steamstatic.com/public/css/promo/winter2019/goldenprofile.css");
+                DOMHelper.insertStylesheet("//community.cloudflare.steamstatic.com/public/css/promo/winter2019/goldenprofile.css");
 
                 const profilePageNode = document.querySelector(".no_header.profile_page");
                 profilePageNode.classList.add("golden_profile");
@@ -49,7 +49,7 @@ export default class FCustomStyle extends Feature {
                             <div class="w19_top"></div>
                             <div class="w19_pendulum">
                                 <div class="w19_strings"></div>
-                                <img src="//cdn.akamai.steamstatic.com/steamcommunity/public/assets/winter2019/goldenprofile/dangle_flake.png">
+                                <img src="//cdn.cloudflare.steamstatic.com/steamcommunity/public/assets/winter2019/goldenprofile/dangle_flake.png">
                             </div>
                         </div>
                         <div class="w19_side right">
@@ -58,7 +58,7 @@ export default class FCustomStyle extends Feature {
                             <div class="w19_top"></div>
                             <div class="w19_pendulum">
                                 <div class="w19_strings"></div>
-                                <img src="//cdn.akamai.steamstatic.com/steamcommunity/public/assets/winter2019/goldenprofile/dangle_flake.png">
+                                <img src="//cdn.cloudflare.steamstatic.com/steamcommunity/public/assets/winter2019/goldenprofile/dangle_flake.png">
                             </div>
                         </div>
                         <div class="snowflakes" aria-hidden="true">
@@ -83,7 +83,7 @@ export default class FCustomStyle extends Feature {
                 break;
             }
             case "goldenprofile2020": {
-                DOMHelper.insertStylesheet("//community.akamai.steamstatic.com/public/css/promo/lny2020/goldenprofile.css");
+                DOMHelper.insertStylesheet("//community.cloudflare.steamstatic.com/public/css/promo/lny2020/goldenprofile.css");
 
                 const profilePageNode = document.querySelector(".no_header.profile_page");
                 profilePageNode.classList.add("golden_profile");
@@ -110,9 +110,9 @@ export default class FCustomStyle extends Feature {
 
                     HTML.afterBegin(profilePageNode,
                         `<div class="profile_animated_background">
-                            <video playsinline autoplay muted loop poster="//cdn.akamai.steamstatic.com/steamcommunity/public/images/items/1223590/daa4b34582ed6cab1327f247be8d03d92ae8aaaa.jpg">
-                                <source src="//cdn.akamai.steamstatic.com/steamcommunity/public/images/items/1223590/c146558951b46ade8d64ea8e787980f84d30ec46.webm" type="video/webm">
-                                <source src="//cdn.akamai.steamstatic.com/steamcommunity/public/images/items/1223590/b5c39efda3998e0d2e734e8b7385ecf705ce8cc5.mp4" type="video/mp4">
+                            <video playsinline autoplay muted loop poster="//cdn.cloudflare.steamstatic.com/steamcommunity/public/images/items/1223590/daa4b34582ed6cab1327f247be8d03d92ae8aaaa.jpg">
+                                <source src="//cdn.cloudflare.steamstatic.com/steamcommunity/public/images/items/1223590/c146558951b46ade8d64ea8e787980f84d30ec46.webm" type="video/webm">
+                                <source src="//cdn.cloudflare.steamstatic.com/steamcommunity/public/images/items/1223590/b5c39efda3998e0d2e734e8b7385ecf705ce8cc5.mp4" type="video/mp4">
                             </video>
                         </div>`);
 
@@ -124,7 +124,7 @@ export default class FCustomStyle extends Feature {
                 break;
             }
             case "goldenprofile": {
-                DOMHelper.insertStylesheet("//community.akamai.steamstatic.com/public/css/promo/lny2019/goldenprofile.css");
+                DOMHelper.insertStylesheet("//community.cloudflare.steamstatic.com/public/css/promo/lny2019/goldenprofile.css");
 
                 const profilePageNode = document.querySelector(".no_header.profile_page");
                 profilePageNode.classList.add("golden_profile");
@@ -138,7 +138,7 @@ export default class FCustomStyle extends Feature {
                             <div class="lny_pig"></div>
                             <div class="lny_pendulum">
                                 <div class="lny_strings"></div>
-                                <img src="//cdn.akamai.steamstatic.com/steamcommunity/public/assets/lny2019/goldenprofile/test_lantern1.png">
+                                <img src="//cdn.cloudflare.steamstatic.com/steamcommunity/public/assets/lny2019/goldenprofile/test_lantern1.png">
                             </div>
                         </div>
                         <div class="lny_side right">
@@ -147,7 +147,7 @@ export default class FCustomStyle extends Feature {
                             <div class="lny_pig"></div>
                             <div class="lny_pendulum">
                                 <div class="lny_strings"></div>
-                                <img src="//cdn.akamai.steamstatic.com/steamcommunity/public/assets/lny2019/goldenprofile/test_lantern2.png">
+                                <img src="//cdn.cloudflare.steamstatic.com/steamcommunity/public/assets/lny2019/goldenprofile/test_lantern2.png">
                             </div>
                         </div>
                     </div>`);
@@ -162,7 +162,7 @@ export default class FCustomStyle extends Feature {
                 break;
             }
             case "holiday2014":
-                DOMHelper.insertStylesheet("//community.akamai.steamstatic.com/public/css/skin_1/holidayprofile.css");
+                DOMHelper.insertStylesheet("//community.cloudflare.steamstatic.com/public/css/skin_1/holidayprofile.css");
 
                 HTML.beforeEnd(".profile_header_bg_texture", "<div class='holidayprofile_header_overlay'></div>");
                 document.querySelector(".no_header.profile_page").classList.add("holidayprofile");

--- a/src/js/Content/Features/Community/ProfileHome/FProfileDropdownOptions.js
+++ b/src/js/Content/Features/Community/ProfileHome/FProfileDropdownOptions.js
@@ -19,7 +19,7 @@ export default class FProfileDropdownOptions extends Feature {
 
                 HTML.afterEnd(this._node,
                     `<a class="popup_menu_item" id="es_nickname">
-                        <img src="//community.akamai.steamstatic.com/public/images/skin_1/notification_icon_edit_bright.png">&nbsp; ${Localization.str.add_nickname}
+                        <img src="//community.cloudflare.steamstatic.com/public/images/skin_1/notification_icon_edit_bright.png">&nbsp; ${Localization.str.add_nickname}
                     </a>`);
 
                 document.querySelector("#es_nickname").addEventListener("click", () => {
@@ -49,7 +49,7 @@ export default class FProfileDropdownOptions extends Feature {
         // add post history link
         HTML.afterEnd(this._node,
             `<a class="popup_menu_item" href="${window.location.pathname}/posthistory">
-                <img src="//community.akamai.steamstatic.com/public/images/skin_1/icon_btn_comment.png">&nbsp; ${Localization.str.post_history}
+                <img src="//community.cloudflare.steamstatic.com/public/images/skin_1/icon_btn_comment.png">&nbsp; ${Localization.str.post_history}
             </a>`);
     }
 }

--- a/src/js/Content/Features/Community/ProfileHome/FProfileDropdownOptions.js
+++ b/src/js/Content/Features/Community/ProfileHome/FProfileDropdownOptions.js
@@ -19,7 +19,7 @@ export default class FProfileDropdownOptions extends Feature {
 
                 HTML.afterEnd(this._node,
                     `<a class="popup_menu_item" id="es_nickname">
-                        <img src="//steamcommunity-a.akamaihd.net/public/images/skin_1/notification_icon_edit_bright.png">&nbsp; ${Localization.str.add_nickname}
+                        <img src="//community.akamai.steamstatic.com/public/images/skin_1/notification_icon_edit_bright.png">&nbsp; ${Localization.str.add_nickname}
                     </a>`);
 
                 document.querySelector("#es_nickname").addEventListener("click", () => {
@@ -49,7 +49,7 @@ export default class FProfileDropdownOptions extends Feature {
         // add post history link
         HTML.afterEnd(this._node,
             `<a class="popup_menu_item" href="${window.location.pathname}/posthistory">
-                <img src="//steamcommunity-a.akamaihd.net/public/images/skin_1/icon_btn_comment.png">&nbsp; ${Localization.str.post_history}
+                <img src="//community.akamai.steamstatic.com/public/images/skin_1/icon_btn_comment.png">&nbsp; ${Localization.str.post_history}
             </a>`);
     }
 }

--- a/src/js/Content/Features/Community/ProfileHome/FTwitchShowcase.js
+++ b/src/js/Content/Features/Community/ProfileHome/FTwitchShowcase.js
@@ -45,7 +45,7 @@ export default class FTwitchShowcase extends Feature {
                 <a class="esi-stream" href="${channelUrl}">
                     <div class="esi-stream__preview">
                         <img src="${previewUrl}">
-                        <img src="//store.akamai.steamstatic.com/public/shared/images/apphubs/play_icon80.png" class="esi-stream__play">
+                        <img src="//store.cloudflare.steamstatic.com/public/shared/images/apphubs/play_icon80.png" class="esi-stream__play">
                         <div class="esi-stream__live">Live on <span class="esi-stream__twitch">Twitch</span></div>
                     </div>
                     <div class="esi-stream__title">

--- a/src/js/Content/Features/Community/ProfileHome/FTwitchShowcase.js
+++ b/src/js/Content/Features/Community/ProfileHome/FTwitchShowcase.js
@@ -38,14 +38,14 @@ export default class FTwitchShowcase extends Feature {
         const previewUrl = `${data.thumbnail_url.replace("{width}", 636).replace("{height}", 358)}?${Math.random()}`;
 
         HTML.afterBegin(".profile_leftcol",
-            `<div class='profile_customization' id='es_twitch'>
-                <div class='profile_customization_header'>
+            `<div class="profile_customization" id="es_twitch">
+                <div class="profile_customization_header">
                     ${Localization.str.twitch.now_streaming.replace("__username__", channelUsername)}
                 </div>
                 <a class="esi-stream" href="${channelUrl}">
                     <div class="esi-stream__preview">
                         <img src="${previewUrl}">
-                        <img src="https://steamstore-a.akamaihd.net/public/shared/images/apphubs/play_icon80.png" class="esi-stream__play">
+                        <img src="//store.akamai.steamstatic.com/public/shared/images/apphubs/play_icon80.png" class="esi-stream__play">
                         <div class="esi-stream__live">Live on <span class="esi-stream__twitch">Twitch</span></div>
                     </div>
                     <div class="esi-stream__title">

--- a/src/js/Content/Features/Community/ProfileHome/FViewSteamId.js
+++ b/src/js/Content/Features/Community/ProfileHome/FViewSteamId.js
@@ -76,7 +76,7 @@ export default class FViewSteamId extends Feature {
         if (dropdown) {
             HTML.beforeEnd(dropdown,
                 `<a class="popup_menu_item" id="es_steamid">
-                    <img src="https://steamcommunity-a.akamaihd.net/public/images/skin_1/iconForums.png">&nbsp; ${Localization.str.view_steamid}
+                    <img src="//community.akamai.steamstatic.com/public/images/skin_1/iconForums.png">&nbsp; ${Localization.str.view_steamid}
                 </a>`);
         } else {
             const actions = document.querySelector(".profile_header_actions");

--- a/src/js/Content/Features/Community/ProfileHome/FViewSteamId.js
+++ b/src/js/Content/Features/Community/ProfileHome/FViewSteamId.js
@@ -76,7 +76,7 @@ export default class FViewSteamId extends Feature {
         if (dropdown) {
             HTML.beforeEnd(dropdown,
                 `<a class="popup_menu_item" id="es_steamid">
-                    <img src="//community.akamai.steamstatic.com/public/images/skin_1/iconForums.png">&nbsp; ${Localization.str.view_steamid}
+                    <img src="//community.cloudflare.steamstatic.com/public/images/skin_1/iconForums.png">&nbsp; ${Localization.str.view_steamid}
                 </a>`);
         } else {
             const actions = document.querySelector(".profile_header_actions");

--- a/src/js/Content/Features/Community/SharedFiles/FSubscribeAllDependencies.js
+++ b/src/js/Content/Features/Community/SharedFiles/FSubscribeAllDependencies.js
@@ -70,7 +70,7 @@ export default class FSubscribeAllDependencies extends Feature {
 
                     const checkmarkHtml
                          = `<div class="requiredItemSubscribed">
-                                <img src="https://community.akamai.steamstatic.com/public/images//sharedfiles/check_header_large.png">
+                                <img src="https://community.cloudflare.steamstatic.com/public/images//sharedfiles/check_header_large.png">
                             </div>`;
 
                     div.classList.add("es_required_item--success");

--- a/src/js/Content/Features/Store/App/FBadgeProgress.js
+++ b/src/js/Content/Features/Store/App/FBadgeProgress.js
@@ -9,7 +9,7 @@ export default class FBadgeProgress extends Feature {
 
     async apply() {
 
-        DOMHelper.insertStylesheet("//community.akamai.steamstatic.com/public/css/skin_1/badges.css");
+        DOMHelper.insertStylesheet("//community.cloudflare.steamstatic.com/public/css/skin_1/badges.css");
 
         HTML.afterEnd("#category_block",
             `<div id="es_badge_progress" class="block responsive_apppage_details_right heading">

--- a/src/js/Content/Features/Store/App/FBadgeProgress.js
+++ b/src/js/Content/Features/Store/App/FBadgeProgress.js
@@ -9,7 +9,7 @@ export default class FBadgeProgress extends Feature {
 
     async apply() {
 
-        DOMHelper.insertStylesheet("//steamcommunity-a.akamaihd.net/public/css/skin_1/badges.css");
+        DOMHelper.insertStylesheet("//community.akamai.steamstatic.com/public/css/skin_1/badges.css");
 
         HTML.afterEnd("#category_block",
             `<div id="es_badge_progress" class="block responsive_apppage_details_right heading">

--- a/src/js/Content/Features/Store/App/FOpenCritic.js
+++ b/src/js/Content/Features/Store/App/FOpenCritic.js
@@ -36,7 +36,7 @@ export default class FOpenCritic extends Feature {
                     <div class="wordmark">
                         <div class="metacritic">OpenCritic</div>
                         <div id="game_area_metalink">${award} - <a href="${data.url}?utm_source=enhanced-steam-itad&utm_medium=average" target="_blank">${Localization.str.read_reviews}</a>
-                            <img src="https://steamstore-a.akamaihd.net/public/images/ico/iconExternalLink.gif" border="0" align="bottom">
+                            <img src="//store.akamai.steamstatic.com/public/images/ico/iconExternalLink.gif" border="0" align="bottom">
                         </div>
                     </div>
                 </div>

--- a/src/js/Content/Features/Store/App/FOpenCritic.js
+++ b/src/js/Content/Features/Store/App/FOpenCritic.js
@@ -36,7 +36,7 @@ export default class FOpenCritic extends Feature {
                     <div class="wordmark">
                         <div class="metacritic">OpenCritic</div>
                         <div id="game_area_metalink">${award} - <a href="${data.url}?utm_source=enhanced-steam-itad&utm_medium=average" target="_blank">${Localization.str.read_reviews}</a>
-                            <img src="//store.akamai.steamstatic.com/public/images/ico/iconExternalLink.gif" border="0" align="bottom">
+                            <img src="//store.cloudflare.steamstatic.com/public/images/ico/iconExternalLink.gif" border="0" align="bottom">
                         </div>
                     </div>
                 </div>

--- a/src/js/Content/Features/Store/App/FRemoveFromWishlist.js
+++ b/src/js/Content/Features/Store/App/FRemoveFromWishlist.js
@@ -19,7 +19,7 @@ export default class FRemoveFromWishlist extends Feature {
         imgNode.classList.add("es-in-wl");
         HTML.beforeBegin(imgNode,
             `<img class="es-remove-wl" src="${ExtensionResources.getURL("img/remove.png")}" style="display: none;">
-            <img class="es-loading-wl" src="//steamcommunity-a.akamaihd.net/public/images/login/throbber.gif" style="display: none;">`);
+            <img class="es-loading-wl" src="//community.akamai.steamstatic.com/public/images/login/throbber.gif" style="display: none;">`);
 
         successBtn.addEventListener("click", async e => {
             e.preventDefault();

--- a/src/js/Content/Features/Store/App/FRemoveFromWishlist.js
+++ b/src/js/Content/Features/Store/App/FRemoveFromWishlist.js
@@ -19,7 +19,7 @@ export default class FRemoveFromWishlist extends Feature {
         imgNode.classList.add("es-in-wl");
         HTML.beforeBegin(imgNode,
             `<img class="es-remove-wl" src="${ExtensionResources.getURL("img/remove.png")}" style="display: none;">
-            <img class="es-loading-wl" src="//community.akamai.steamstatic.com/public/images/login/throbber.gif" style="display: none;">`);
+            <img class="es-loading-wl" src="//community.cloudflare.steamstatic.com/public/images/login/throbber.gif" style="display: none;">`);
 
         successBtn.addEventListener("click", async e => {
             e.preventDefault();

--- a/src/js/Content/Features/Store/App/FShowCoupon.js
+++ b/src/js/Content/Features/Store/App/FShowCoupon.js
@@ -22,7 +22,7 @@ export default class FShowCoupon extends Feature {
                 </div>
                 <div class="devnotes">
                     <div style="display:flex;padding-top:10px">
-                        <img src="//steamcommunity-a.akamaihd.net/economy/image/${coupon.image_url}" style="width:96px;height:64px;">
+                        <img src="//community.akamai.steamstatic.com/economy/image/${coupon.image_url}" style="width:96px;height:64px;">
                         <div style="display:flex;flex-direction:column;margin-left:10px">
                             <h1 style="margin-top:2px">${coupon.title}</h1>
                             <div>${coupon.discount_note || ""}</div>

--- a/src/js/Content/Features/Store/App/FShowCoupon.js
+++ b/src/js/Content/Features/Store/App/FShowCoupon.js
@@ -22,7 +22,7 @@ export default class FShowCoupon extends Feature {
                 </div>
                 <div class="devnotes">
                     <div style="display:flex;padding-top:10px">
-                        <img src="//community.akamai.steamstatic.com/economy/image/${coupon.image_url}" style="width:96px;height:64px;">
+                        <img src="//community.cloudflare.steamstatic.com/economy/image/${coupon.image_url}" style="width:96px;height:64px;">
                         <div style="display:flex;flex-direction:column;margin-left:10px">
                             <h1 style="margin-top:2px">${coupon.title}</h1>
                             <div>${coupon.discount_note || ""}</div>

--- a/src/js/Content/Features/Store/App/FSteamPeek.js
+++ b/src/js/Content/Features/Store/App/FSteamPeek.js
@@ -73,7 +73,7 @@ export default class FSteamPeek extends Feature {
                 for (const {title, appid} of data) {
                     HTML.beforeBegin(lastChild,
                         `<a class="small_cap es_sp_similar" data-ds-appid="${appid}" href="https://store.steampowered.com/app/${appid}/">
-                            <img src="https://steamcdn-a.akamaihd.net/steam/apps/${appid}/capsule_184x69.jpg" class="small_cap_img"></img>
+                            <img src="//cdn.akamai.steamstatic.com/steam/apps/${appid}/capsule_184x69.jpg" class="small_cap_img"></img>
                             <h4>${title}</h4>
                         </a>`);
 

--- a/src/js/Content/Features/Store/App/FSteamPeek.js
+++ b/src/js/Content/Features/Store/App/FSteamPeek.js
@@ -73,7 +73,7 @@ export default class FSteamPeek extends Feature {
                 for (const {title, appid} of data) {
                     HTML.beforeBegin(lastChild,
                         `<a class="small_cap es_sp_similar" data-ds-appid="${appid}" href="https://store.steampowered.com/app/${appid}/">
-                            <img src="//cdn.akamai.steamstatic.com/steam/apps/${appid}/capsule_184x69.jpg" class="small_cap_img"></img>
+                            <img src="//cdn.cloudflare.steamstatic.com/steam/apps/${appid}/capsule_184x69.jpg" class="small_cap_img"></img>
                             <h4>${title}</h4>
                         </a>`);
 

--- a/src/js/Content/Features/Store/App/FWaitlistDropdown.js
+++ b/src/js/Content/Features/Store/App/FWaitlistDropdown.js
@@ -39,14 +39,14 @@ export default class FWaitlistDropdown extends Feature {
         HTML.afterEnd(wrapper,
             `<div class="queue_control_button queue_btn_menu as_btn_wishlist_menu">
                 <div class="queue_menu_arrow btn_medium">
-                    <span><img src="https://steamstore-a.akamaihd.net/public/images/v6/btn_arrow_down_padded.png"></span>
+                    <span><img src="//store.akamai.steamstatic.com/public/images/v6/btn_arrow_down_padded.png"></span>
                 </div>
                 <div class="queue_menu_flyout">
                     <div class="queue_menu_flyout_content">
                         <div class="queue_menu_option" id="queue_menu_option_on_wishlist">
                             <div>
-                                <img class="queue_ignore_menu_option_image selected" src="https://steamstore-a.akamaihd.net/public/images/v6/ico/ico_selected_bright.png">
-                                <img class="queue_ignore_menu_option_image unselected" src="https://steamstore-a.akamaihd.net/public/images/v6/ico/ico_unselected_bright.png">
+                                <img class="queue_ignore_menu_option_image selected" src="//store.akamai.steamstatic.com/public/images/v6/ico/ico_selected_bright.png">
+                                <img class="queue_ignore_menu_option_image unselected" src="//store.akamai.steamstatic.com/public/images/v6/ico/ico_unselected_bright.png">
                             </div>
                             <div class="queue_menu_option_label">
                                 <div class="option_title">${Localization.str.wishlist} (${Localization.str.theworddefault})</div>
@@ -55,8 +55,8 @@ export default class FWaitlistDropdown extends Feature {
                         </div>
                         <div class="queue_menu_option" id="queue_menu_option_on_waitlist">
                             <div>
-                                <img class="queue_ignore_menu_option_image selected" src="https://steamstore-a.akamaihd.net/public/images/v6/ico/ico_selected_bright.png">
-                                <img class="queue_ignore_menu_option_image unselected" src="https://steamstore-a.akamaihd.net/public/images/v6/ico/ico_unselected_bright.png">
+                                <img class="queue_ignore_menu_option_image selected" src="//store.akamai.steamstatic.com/public/images/v6/ico/ico_selected_bright.png">
+                                <img class="queue_ignore_menu_option_image unselected" src="//store.akamai.steamstatic.com/public/images/v6/ico/ico_unselected_bright.png">
                             </div>
                             <div class="queue_menu_option_label">
                                 <div class="option_title">Waitlist</div>

--- a/src/js/Content/Features/Store/App/FWaitlistDropdown.js
+++ b/src/js/Content/Features/Store/App/FWaitlistDropdown.js
@@ -39,14 +39,14 @@ export default class FWaitlistDropdown extends Feature {
         HTML.afterEnd(wrapper,
             `<div class="queue_control_button queue_btn_menu as_btn_wishlist_menu">
                 <div class="queue_menu_arrow btn_medium">
-                    <span><img src="//store.akamai.steamstatic.com/public/images/v6/btn_arrow_down_padded.png"></span>
+                    <span><img src="//store.cloudflare.steamstatic.com/public/images/v6/btn_arrow_down_padded.png"></span>
                 </div>
                 <div class="queue_menu_flyout">
                     <div class="queue_menu_flyout_content">
                         <div class="queue_menu_option" id="queue_menu_option_on_wishlist">
                             <div>
-                                <img class="queue_ignore_menu_option_image selected" src="//store.akamai.steamstatic.com/public/images/v6/ico/ico_selected_bright.png">
-                                <img class="queue_ignore_menu_option_image unselected" src="//store.akamai.steamstatic.com/public/images/v6/ico/ico_unselected_bright.png">
+                                <img class="queue_ignore_menu_option_image selected" src="//store.cloudflare.steamstatic.com/public/images/v6/ico/ico_selected_bright.png">
+                                <img class="queue_ignore_menu_option_image unselected" src="//store.cloudflare.steamstatic.com/public/images/v6/ico/ico_unselected_bright.png">
                             </div>
                             <div class="queue_menu_option_label">
                                 <div class="option_title">${Localization.str.wishlist} (${Localization.str.theworddefault})</div>
@@ -55,8 +55,8 @@ export default class FWaitlistDropdown extends Feature {
                         </div>
                         <div class="queue_menu_option" id="queue_menu_option_on_waitlist">
                             <div>
-                                <img class="queue_ignore_menu_option_image selected" src="//store.akamai.steamstatic.com/public/images/v6/ico/ico_selected_bright.png">
-                                <img class="queue_ignore_menu_option_image unselected" src="//store.akamai.steamstatic.com/public/images/v6/ico/ico_unselected_bright.png">
+                                <img class="queue_ignore_menu_option_image selected" src="//store.cloudflare.steamstatic.com/public/images/v6/ico/ico_selected_bright.png">
+                                <img class="queue_ignore_menu_option_image unselected" src="//store.cloudflare.steamstatic.com/public/images/v6/ico/ico_unselected_bright.png">
                             </div>
                             <div class="queue_menu_option_label">
                                 <div class="option_title">Waitlist</div>

--- a/src/js/Content/Features/Store/Common/FCustomizer.js
+++ b/src/js/Content/Features/Store/Common/FCustomizer.js
@@ -8,7 +8,7 @@ export default class FCustomizer extends Feature {
 
         HTML.afterBegin("#cart_status_data",
             `<div class="store_header_btn_gray store_header_btn" id="es_customize_btn">
-                <div class="es_customize_title">${Localization.str.customize}<img src="//steamstore-a.akamaihd.net/public/images/v6/btn_arrow_down_padded_white.png"></div>
+                <div class="es_customize_title">${Localization.str.customize}<img src="//store.akamai.steamstatic.com/public/images/v6/btn_arrow_down_padded_white.png"></div>
                 <div class="home_viewsettings_popup">
                     <div class="home_viewsettings_instructions">${Localization.str.apppage_sections}</div>
                 </div>

--- a/src/js/Content/Features/Store/Common/FCustomizer.js
+++ b/src/js/Content/Features/Store/Common/FCustomizer.js
@@ -8,7 +8,7 @@ export default class FCustomizer extends Feature {
 
         HTML.afterBegin("#cart_status_data",
             `<div class="store_header_btn_gray store_header_btn" id="es_customize_btn">
-                <div class="es_customize_title">${Localization.str.customize}<img src="//store.akamai.steamstatic.com/public/images/v6/btn_arrow_down_padded_white.png"></div>
+                <div class="es_customize_title">${Localization.str.customize}<img src="//store.cloudflare.steamstatic.com/public/images/v6/btn_arrow_down_padded_white.png"></div>
                 <div class="home_viewsettings_popup">
                     <div class="home_viewsettings_instructions">${Localization.str.apppage_sections}</div>
                 </div>

--- a/src/js/Content/Modules/AugmentedSteam.js
+++ b/src/js/Content/Modules/AugmentedSteam.js
@@ -272,7 +272,7 @@ class AugmentedSteam {
                 Page.runInPageContext((playGameStr, gameid, visitStore) => {
                     const prompt = window.SteamFacade.showConfirmDialog(
                         playGameStr,
-                        `<img src="//steamcdn-a.akamaihd.net/steam/apps/${gameid}/header.jpg">`,
+                        `<img src="//cdn.akamai.steamstatic.com/steam/apps/${gameid}/header.jpg">`,
                         null,
                         null,
                         visitStore

--- a/src/js/Content/Modules/AugmentedSteam.js
+++ b/src/js/Content/Modules/AugmentedSteam.js
@@ -272,7 +272,7 @@ class AugmentedSteam {
                 Page.runInPageContext((playGameStr, gameid, visitStore) => {
                     const prompt = window.SteamFacade.showConfirmDialog(
                         playGameStr,
-                        `<img src="//cdn.akamai.steamstatic.com/steam/apps/${gameid}/header.jpg">`,
+                        `<img src="//cdn.cloudflare.steamstatic.com/steam/apps/${gameid}/header.jpg">`,
                         null,
                         null,
                         visitStore

--- a/src/js/Content/Modules/Community/CommentHandler.js
+++ b/src/js/Content/Modules/Community/CommentHandler.js
@@ -149,7 +149,7 @@ export class CommentHandler {
     }
 
     static _buildEmoticonOption(name) {
-        return `<div class="emoticon_option es_fav" data-emoticon="${name}"><img src="//community.akamai.steamstatic.com/economy/emoticon/${name}" class="emoticon"></div>`;
+        return `<div class="emoticon_option es_fav" data-emoticon="${name}"><img src="//community.cloudflare.steamstatic.com/economy/emoticon/${name}" class="emoticon"></div>`;
     }
 
     static addFavoriteEmoticons() {

--- a/src/js/Content/Modules/Community/CommentHandler.js
+++ b/src/js/Content/Modules/Community/CommentHandler.js
@@ -149,7 +149,7 @@ export class CommentHandler {
     }
 
     static _buildEmoticonOption(name) {
-        return `<div class="emoticon_option es_fav" data-emoticon="${name}"><img src="https://steamcommunity-a.akamaihd.net/economy/emoticon/${name}" class="emoticon"></div>`;
+        return `<div class="emoticon_option es_fav" data-emoticon="${name}"><img src="//community.akamai.steamstatic.com/economy/emoticon/${name}" class="emoticon"></div>`;
     }
 
     static addFavoriteEmoticons() {

--- a/src/js/Content/Modules/Stats.js
+++ b/src/js/Content/Modules/Stats.js
@@ -67,10 +67,10 @@ class Stats {
         return `<div class="recentAchievements">
             ${achievementStr}
             <br>
-            <img src="https://community.akamai.steamstatic.com/public/images/skin_1/achieveBarLeft.gif" width="2" height="12" border="0">
-            <img src="https://community.akamai.steamstatic.com/public/images/skin_1/achieveBarFull.gif" width="${achBarWidth}" height="12" border="0">
-            <img src="https://community.akamai.steamstatic.com/public/images/skin_1/achieveBarEmpty.gif" width="${achBarWidthRemainder}" height="12" border="0">
-            <img src="https://community.akamai.steamstatic.com/public/images/skin_1/achieveBarRight.gif" width="2" height="12" border="0">
+            <img src="https://community.cloudflare.steamstatic.com/public/images/skin_1/achieveBarLeft.gif" width="2" height="12" border="0">
+            <img src="https://community.cloudflare.steamstatic.com/public/images/skin_1/achieveBarFull.gif" width="${achBarWidth}" height="12" border="0">
+            <img src="https://community.cloudflare.steamstatic.com/public/images/skin_1/achieveBarEmpty.gif" width="${achBarWidthRemainder}" height="12" border="0">
+            <img src="https://community.cloudflare.steamstatic.com/public/images/skin_1/achieveBarRight.gif" width="2" height="12" border="0">
             <br>
         </div>`.replace(/>\s+</g, "><"); // Remove whitespace between tags to avoid layout issues
     }

--- a/src/js/Steam/holidayprofile.js
+++ b/src/js/Steam/holidayprofile.js
@@ -8,72 +8,72 @@ const animationDefaults = {
 
 const animations = [
     {
-        "image": "https://steamcommunity-a.akamaihd.net/public/images/profile/holidayprofile/sprite_sheets/crushed/ball_blink_1170_9_69.png",
+        "image": "https://community.cloudflare.steamstatic.com/public/images/profile/holidayprofile/sprite_sheets/crushed/ball_blink_1170_9_69.png",
         "cols": 9,
         "frames": 69
     },
     {
-        "image": "https://steamcommunity-a.akamaihd.net/public/images/profile/holidayprofile/sprite_sheets/crushed/ball_jump_650_5_25.png",
+        "image": "https://community.cloudflare.steamstatic.com/public/images/profile/holidayprofile/sprite_sheets/crushed/ball_jump_650_5_25.png",
         "cols": 5,
         "frames": 25
     },
     {
-        "image": "https://steamcommunity-a.akamaihd.net/public/images/profile/holidayprofile/sprite_sheets/crushed/ball_wave_1170_9_78.png",
+        "image": "https://community.cloudflare.steamstatic.com/public/images/profile/holidayprofile/sprite_sheets/crushed/ball_wave_1170_9_78.png",
         "cols": 9,
         "frames": 78
     },
     {
-        "image": "https://steamcommunity-a.akamaihd.net/public/images/profile/holidayprofile/sprite_sheets/crushed/cupcake_blink_1040_8_60.png",
+        "image": "https://community.cloudflare.steamstatic.com/public/images/profile/holidayprofile/sprite_sheets/crushed/cupcake_blink_1040_8_60.png",
         "cols": 8,
         "frames": 60
     },
     {
-        "image": "https://steamcommunity-a.akamaihd.net/public/images/profile/holidayprofile/sprite_sheets/crushed/cupcake_jump_650_5_25.png",
+        "image": "https://community.cloudflare.steamstatic.com/public/images/profile/holidayprofile/sprite_sheets/crushed/cupcake_jump_650_5_25.png",
         "cols": 5,
         "frames": 25
     },
     {
-        "image": "https://steamcommunity-a.akamaihd.net/public/images/profile/holidayprofile/sprite_sheets/crushed/cupcake_wave_1040_8_54.png",
+        "image": "https://community.cloudflare.steamstatic.com/public/images/profile/holidayprofile/sprite_sheets/crushed/cupcake_wave_1040_8_54.png",
         "cols": 8,
         "frames": 54
     },
     {
-        "image": "https://steamcommunity-a.akamaihd.net/public/images/profile/holidayprofile/sprite_sheets/crushed/monte_blink_1040_8_62.png",
+        "image": "https://community.cloudflare.steamstatic.com/public/images/profile/holidayprofile/sprite_sheets/crushed/monte_blink_1040_8_62.png",
         "cols": 8,
         "frames": 62
     },
     {
-        "image": "https://steamcommunity-a.akamaihd.net/public/images/profile/holidayprofile/sprite_sheets/crushed/monte_wave_1040_8_57.png",
+        "image": "https://community.cloudflare.steamstatic.com/public/images/profile/holidayprofile/sprite_sheets/crushed/monte_wave_1040_8_57.png",
         "cols": 8,
         "frames": 57
     },
     {
-        "image": "https://steamcommunity-a.akamaihd.net/public/images/profile/holidayprofile/sprite_sheets/crushed/runner_blink_1170_9_72.png",
+        "image": "https://community.cloudflare.steamstatic.com/public/images/profile/holidayprofile/sprite_sheets/crushed/runner_blink_1170_9_72.png",
         "cols": 9,
         "frames": 72
     },
     {
-        "image": "https://steamcommunity-a.akamaihd.net/public/images/profile/holidayprofile/sprite_sheets/crushed/runner_present_1170_9_79.png",
+        "image": "https://community.cloudflare.steamstatic.com/public/images/profile/holidayprofile/sprite_sheets/crushed/runner_present_1170_9_79.png",
         "cols": 9,
         "frames": 79
     },
     {
-        "image": "https://steamcommunity-a.akamaihd.net/public/images/profile/holidayprofile/sprite_sheets/crushed/runner_wave_1170_9_68.png",
+        "image": "https://community.cloudflare.steamstatic.com/public/images/profile/holidayprofile/sprite_sheets/crushed/runner_wave_1170_9_68.png",
         "cols": 9,
         "frames": 68
     },
     {
-        "image": "https://steamcommunity-a.akamaihd.net/public/images/profile/holidayprofile/sprite_sheets/crushed/zippy_blink_1040_8_59.png",
+        "image": "https://community.cloudflare.steamstatic.com/public/images/profile/holidayprofile/sprite_sheets/crushed/zippy_blink_1040_8_59.png",
         "cols": 8,
         "frames": 59
     },
     {
-        "image": "https://steamcommunity-a.akamaihd.net/public/images/profile/holidayprofile/sprite_sheets/crushed/zippy_shiv_910_7_46.png",
+        "image": "https://community.cloudflare.steamstatic.com/public/images/profile/holidayprofile/sprite_sheets/crushed/zippy_shiv_910_7_46.png",
         "cols": 7,
         "frames": 46
     },
     {
-        "image": "https://steamcommunity-a.akamaihd.net/public/images/profile/holidayprofile/sprite_sheets/crushed/zippy_wave_910_7_45.png",
+        "image": "https://community.cloudflare.steamstatic.com/public/images/profile/holidayprofile/sprite_sheets/crushed/zippy_wave_910_7_45.png",
         "cols": 7,
         "frames": 45
     }


### PR DESCRIPTION
Steam has been using these new hosts for a while now:
`steamcdn-a.akamaihd.net` -> `cdn.akamai.steamstatic.com`
`steamcommunity-a.akamaihd.net` -> `community.akamai.steamstatic.com`
`steamstore-a.akamaihd.net` -> `store.akamai.steamstatic.com`

Did I manage to catch all of them?
We might be better off storing some images (e.g. throbber.gif) locally, I'll do that later if needed...