### PR TITLE
Don't show HLTB section if there's no data, improve CSS styles

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -2310,7 +2310,20 @@ label.es_dlc_label > input:checked::after {
 }
 
 
-.es_hltb .details_block span {
+/* Taken from store_game_shared.css (.game_details) */
+.es_hltb {
+  color: #8f98a0;
+  line-height: 20px;
+}
+.es_hltb b {
+  font-family: Arial, Helvetica, sans-serif;
+  color: #556772;
+  font-weight: normal;
+  text-transform: uppercase;
+  font-size: 10px;
+}
+
+.es_hltb span {
   float: right;
 }
 

--- a/src/js/Content/Features/Store/App/FHowLongToBeat.js
+++ b/src/js/Content/Features/Store/App/FHowLongToBeat.js
@@ -11,12 +11,9 @@ export default class FHowLongToBeat extends Feature {
         }
 
         const result = await this.context.data;
-        if (!result || !result.hltb) {
+        if (!result || !result.hltb || !result.hltb.success) {
             return false;
         }
-
-        // TODO remove when suggestion link is fixed
-        if (!result.hltb.success) { return false; }
 
         this._data = result.hltb;
         return true;
@@ -24,32 +21,29 @@ export default class FHowLongToBeat extends Feature {
 
     apply() {
 
-        const data = this._data;
+        const {
+            "main_story": story,
+            "main_extras": extras,
+            comp,
+            url,
+            "submit_url": submit,
+        } = this._data;
 
-        let html = `<div class="block responsive_apppage_details_right heading">${Localization.str.hltb.title}</div>
-                    <div class="block game_details underlined_links es_hltb">
-                    <div class="block_content"><div class="block_content_inner"><div class="details_block">`;
-
-        if (data.success) {
-            if (data.main_story) {
-                html += `<b>${Localization.str.hltb.main}:</b><span>${HTML.escape(data.main_story)}</span><br>`;
-            }
-            if (data.main_extras) {
-                html += `<b>${Localization.str.hltb.main_e}:</b><span>${HTML.escape(data.main_extras)}</span><br>`;
-            }
-            if (data.comp) {
-                html += `<b>${Localization.str.hltb.compl}:</b><span>${HTML.escape(data.comp)}</span><br>`;
-            }
-
-            html += `</div>
-                    <a class="linkbar es_external_icon" href="${HTML.escape(data.url)}" target="_blank">${Localization.str.more_information}</a>
-                    <a class="linkbar es_external_icon" href="${HTML.escape(data.submit_url)}" target="_blank">${Localization.str.hltb.submit}</a>`;
-        } else {
-            html += `${Localization.str.hltb.no_data}</div>`;
-        }
-
-        html += "</div></div></div>";
-
-        HTML.afterEnd("div.game_details", html);
+        HTML.afterEnd("div.game_details",
+            `<div class="block responsive_apppage_details_right heading">${Localization.str.hltb.title}</div>
+            <div class="block underlined_links es_hltb">
+                <div class="block_content">
+                    <div class="block_content_inner">
+                        <div class="details_block">
+                            ${story ? `<b>${Localization.str.hltb.main}:</b><span>${HTML.escape(story)}</span><br>` : ""}
+                            ${extras ? `<b>${Localization.str.hltb.main_e}:</b><span>${HTML.escape(extras)}</span><br>` : ""}
+                            ${comp ? `<b>${Localization.str.hltb.compl}:</b><span>${HTML.escape(comp)}</span><br>` : ""}
+                        </div>
+                        <br>
+                        <a class="linkbar es_external_icon" href="${HTML.escape(url)}" target="_blank">${Localization.str.more_information}</a>
+                        <a class="linkbar es_external_icon" href="${HTML.escape(submit)}" target="_blank">${Localization.str.hltb.submit}</a>
+                    </div>
+                </div>
+            </div>`);
     }
 }


### PR DESCRIPTION
This feature should be more reliable now, so no data (`data.success` is false) likely means there's no entry on HLTB, and there's nothing to do on our end.

Also copied the styles we were relying on to our own CSS file. This makes it easier to customize in the future, and avoids inserting an extra `game_details` class into the page, which may get in the way of maintaining feature order. (other features anchor on to this node)