### PR TITLE
Added display of SteamID64 Hex variant in profile

### DIFF
--- a/src/js/Content/Features/Community/ProfileHome/FViewSteamId.js
+++ b/src/js/Content/Features/Community/ProfileHome/FViewSteamId.js
@@ -34,6 +34,7 @@ export default class FViewSteamId extends Feature {
                 steamId.id2,
                 steamId.id3,
                 steamId.id64,
+                steamId.id64hex,
                 `https://steamcommunity.com/profiles/${steamId.id64}`
             ];
 

--- a/src/js/Content/Modules/SteamId.js
+++ b/src/js/Content/Modules/SteamId.js
@@ -118,6 +118,10 @@ class SteamIdDetail {
     get id64() {
         return this._steamId64;
     }
+
+    get id64hex() {
+        return `steam:${BigInt(this._steamId64).toString(16)}`;
+    }
 }
 
 export {SteamId, SteamIdDetail};


### PR DESCRIPTION
SteamID64 is commonly displayed as a hex string in the CFX.re platforms (FiveM, RedM). Addition of this way of displaying the SteamID will definitely come in handy for many people. 