### PR TITLE
Further simplify skipping age gate

### DIFF
--- a/src/js/Content/Features/Common/FSkipAgecheck.js
+++ b/src/js/Content/Features/Common/FSkipAgecheck.js
@@ -1,6 +1,5 @@
 import {SyncedStorage} from "../../../Core/Storage/SyncedStorage";
 import {ContextType, Feature} from "../../modulesContent";
-import {Page} from "../Page";
 
 export default class FSkipAgecheck extends Feature {
 
@@ -12,26 +11,21 @@ export default class FSkipAgecheck extends Feature {
 
         if (this.context.type === ContextType.AGECHECK) {
 
-            Page.runInPageContext(() => {
+            // Partially taken from https://github.com/SteamDatabase/BrowserExtension/blob/master/scripts/store/agecheck.js
+            const year = Math.floor(Math.random() * 35) + 50;
+            const time = new Date(year, 0) / 1000; // Jan 01 19xx 00:00:00 GMT+0800
 
-                // Modified version of `HideAgeGate` from the page script
-                function newHideAgeGate() {
-                    const cookiePath = window.location.pathname.replace("/agecheck", "");
-                    window.SteamFacade.vSetCookie("wants_mature_content", 1, 365, cookiePath);
-                    window.location.replace(window.location.origin + cookiePath);
-                }
+            let expiry = new Date();
+            expiry.setFullYear(expiry.getFullYear() + 1);
+            expiry = expiry.toUTCString();
 
-                const ageYearNode = document.querySelector("#ageYear");
-                if (ageYearNode) { // Game may contain content nsfw...
-                    const myYear = Math.floor(Math.random() * 75) + 10;
-                    ageYearNode.value = `19${myYear}`;
+            document.cookie = `birthtime=${time}; expires=${expiry}; path=/;`;
+            document.cookie = `wants_mature_content=1; expires=${expiry}; path=/;`;
 
-                    window.SteamFacade.checkAgeGateSubmit(newHideAgeGate);
-                } else { // Game contains content you have asked not to see
-                    // `CheckAgeGateSubmit` calls `HideAgeGate` on these pages, so bypass it completely
-                    newHideAgeGate();
-                }
-            });
+            // Make sure there's a valid age gate before redirecting
+            if (document.querySelector("#app_agegate")) {
+                window.location.href = window.location.href.replace("/agecheck", "");
+            }
         } else {
             this._skipContentWarning();
 
@@ -47,9 +41,6 @@ export default class FSkipAgecheck extends Feature {
     }
 
     _skipContentWarning() {
-        const btn = document.querySelector("#age_gate_btn_continue");
-        if (btn) {
-            btn.click();
-        }
+        document.querySelector("#age_gate_btn_continue")?.click();
     }
 }

--- a/src/js/Content/Modules/SteamFacade.js
+++ b/src/js/Content/Modules/SteamFacade.js
@@ -151,14 +151,6 @@ class SteamFacade {
         CScrollOffsetWatcher.ForceRecalc();
     }
 
-    static vSetCookie(strCookieName, strValue, expiryInDays, path) {
-        V_SetCookie(strCookieName, strValue, expiryInDays, path);
-    }
-
-    static checkAgeGateSubmit(callbackFunc) {
-        CheckAgeGateSubmit(callbackFunc);
-    }
-
     static loadImageGroupOnScroll(elTarget, strGroup) {
         LoadImageGroupOnScroll(elTarget, strGroup);
     }


### PR DESCRIPTION
I recently learned about the actual reason that lead to the annoying behaviour I mentioned in #1236, it is that browsers will save a navigation to history if it was a result of a user action, and since we simulated clicking the "Continue" button, it counted as a user action. To avoid this we can simply trigger the navigation programmatically, and avoid running a script in the page.

Implementation partially taken from https://github.com/SteamDatabase/BrowserExtension/blob/master/scripts/store/agecheck.js.