### PR TITLE
Refactor market listings sort

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1859,46 +1859,6 @@ img.astats_icon {
 }
 
 /***************************************
- * Market
- * add_market_sort()
- **************************************/
-.es_marketsort {
-  cursor: pointer;
-  display: inline-block;
-  float: right;
-}
-#es_marketsort_name {
-  display: block;
-  float: none;
-}
-#es_marketsort_game {
-  width: 165px;
-  padding-left: 5px;
-}
-.es_marketsort.active span:last-child::after {
-  display: inline;
-  margin-left: 4px;
-  margin-right: -16px;
-  color: #eee;
-  font-size: 12px;
-}
-.es_marketsort.active.asc span:last-child::after {
-  content: "▲";
-}
-.es_marketsort.active.desc span:last-child::after {
-  content: "▼";
-}
-#tabContentsMyActiveMarketListingsTable .market_listing_table_header {
-  overflow: hidden;
-}
-#tabContentsMyActiveMarketListingsTable .market_listing_header_namespacer {
-  visibility: hidden;
-}
-.market_listing_listed_position {
-  display: none;
-}
-
-/***************************************
  * Augmented Steam and ITAD menu
  **************************************/
 #es_menu {

--- a/src/js/Content/Features/Community/FriendsAndGroups/FGroupsSort.js
+++ b/src/js/Content/Features/Community/FriendsAndGroups/FGroupsSort.js
@@ -31,30 +31,24 @@ export default class FGroupsSort extends CallbackFeature {
     _sortGroups(sortBy, reversed) {
 
         if (this._initSort) {
-
-            let i = 0;
-            for (const group of this._groups) {
-                const name = group.querySelector(".groupTitle > a").textContent;
-                const membercount = Number(group.querySelector(".memberRow > a").textContent.match(/\d+/g).join(""));
-                group.dataset.esSortdefault = i.toString();
-                group.dataset.esSortnames = name;
-                group.dataset.esSortmembers = membercount.toString();
-                i++;
-            }
+            this._groups.forEach((group, i) => {
+                group.dataset.esSortdefault = i;
+                group.dataset.esSortnames = group.querySelector(".groupTitle > a").textContent;
+                group.dataset.esSortmembers = group.querySelector(".memberRow > a").textContent.match(/\d+/g).join("");
+            });
 
             this._initSort = false;
         }
 
-        this._groups.sort(this._getSortFunc(sortBy, `esSort${sortBy}`));
+        this._groups.sort(this._getSortFunc(sortBy));
 
-        const searchResults = document.querySelector("#search_results_empty");
-        for (const group of this._groups) {
-            if (reversed) {
-                searchResults.insertAdjacentElement("afterend", group);
-            } else {
-                searchResults.parentElement.appendChild(group);
-            }
+        if (reversed) {
+            this._groups.reverse();
         }
+
+        // TODO better indicator for primary group document.getElementById("primaryGroupBreak");
+        const searchResults = document.getElementById("search_results");
+        this._groups.forEach(group => searchResults.append(group));
     }
 
     _getSortFunc(sortBy) {

--- a/src/js/Content/Modules/DOMHelper.js
+++ b/src/js/Content/Modules/DOMHelper.js
@@ -1,13 +1,6 @@
 
 class DOMHelper {
 
-    static wrap(container, node) {
-        const parent = node.parentNode;
-        parent.insertBefore(container, node);
-        parent.removeChild(node);
-        container.append(node);
-    }
-
     static remove(selector) {
         const node = document.querySelector(selector);
         if (!node) { return; }

--- a/src/js/Content/Modules/Widgets/SortBox.js
+++ b/src/js/Content/Modules/Widgets/SortBox.js
@@ -7,8 +7,7 @@ import {SyncedStorage} from "../../../Core/Storage/SyncedStorage";
 class Sortbox {
 
     static init() {
-        this._activeDropLists = {};
-        this._lastSelectHideTime = 0;
+        this.reset();
 
         // Hide droplist when clicking outside
         document.addEventListener("mousedown", e => {
@@ -18,6 +17,11 @@ class Sortbox {
                 }
             }
         });
+    }
+
+    static reset() {
+        this._activeDropLists = {};
+        this._lastSelectHideTime = 0;
     }
 
     static _highlightItem(id, index, bSetSelected) {

--- a/src/js/Core/Storage/SyncedStorage.js
+++ b/src/js/Core/Storage/SyncedStorage.js
@@ -191,6 +191,7 @@ SyncedStorage.defaults = Object.freeze({
     "sortfriendsby": "default_ASC",
     "sortreviewsby": "default_ASC",
     "sortgroupsby": "default_ASC",
+    "sortmylistingsby": "default_ASC",
     "show1clickgoo": true,
     "show_profile_link_images": "gray",
     "show_custom_themes": true,


### PR DESCRIPTION
Refactor to use our `Sortbox` implementation to resolve #1369, while fixing a couple of bugs this feature had, the most broken one being sorting then changing page controls, because we were inserting rows into the wrong container. Also fixed sorting by price (we were using string comparison so e.g. `"10" < "2"`). Based on the implementation from groups and friends sort, and cleaned up those feature a bit while at it.

A problem I encountered was we have to reset the sortbox in certain conditions, and I haven't found a good way to do that other than removing and re-inserting the element.

Another thing to note is we don't add sorting options for listings on hold, unlike adding lowest prices. I suppose they work the same so we can probably just query the container and add it and hope for the best, but I ain't gonna disable SteamGuard to test it 😆.