### PR TITLE
Deduplicate and improve `Stats.getAchievementBar`

### DIFF
--- a/src/js/Content/Features/Community/Games/FGamelistAchievements.js
+++ b/src/js/Content/Features/Community/Games/FGamelistAchievements.js
@@ -34,7 +34,7 @@ export default class FGamelistAchievements extends Feature {
             }
 
             const appid = GameId.getAppidFromId(node.id);
-            const achieveBar = await Stats.getAchievementBarForGamelist(this._path, appid);
+            const achieveBar = await Stats.getAchievementBar(this._path, appid, true);
             if (!achieveBar) { continue; }
 
             HTML.afterBegin(node.querySelector(".gameListRowItem"), achieveBar);

--- a/src/js/Content/Modules/Stats.js
+++ b/src/js/Content/Modules/Stats.js
@@ -4,78 +4,58 @@ import {Background} from "./Background";
 
 class Stats {
 
-    static async getAchievementBar(path, appid) {
+    static async getAchievementBar(path, appid, altStyle = false) {
 
         const html = await Background.action("stats", path, appid);
-        const dummy = HTMLParser.htmlToDOM(html);
-        const achNode = dummy.querySelector("#topSummaryAchievements");
-
+        const achNode = HTMLParser.htmlToDOM(html).querySelector("#topSummaryAchievements");
         if (!achNode) { return null; }
 
-        achNode.style.whiteSpace = "nowrap";
-
-        if (!achNode.querySelector("img")) {
-
-            // The size of the achievement bars for games without leaderboards/other stats is fine, return
+        // Games without leaderboards will have "grey" style achievement bars, return them
+        if (!altStyle && !achNode.querySelector("img")) {
             return achNode.innerHTML;
         }
 
-        const stats = achNode.innerHTML.match(/(\d+) of (\d+) \((\d{1,3})%\)/);
+        // Placement of % sign varies, but percentage always comes last, so match numbers only
+        const stats = achNode.textContent.trim().match(/\d+/g);
+        if (!stats || stats.length !== 3) { return null; }
 
-        // 1 full match, 3 group matches
-        if (!stats || stats.length !== 4) {
-            return null;
+        let [unlocked, total, percentage] = stats.map(Number);
+
+        // Total comes before unlocked in some locales
+        if (unlocked > total) {
+            [unlocked, total] = [total, unlocked];
         }
 
+        // Some games report 0 total achievements for whatever reason
+        if (total === 0) { return null; }
+
         const achievementStr = Localization.str.achievements.summary
-            .replace("__unlocked__", stats[1])
-            .replace("__total__", stats[2])
-            .replace("__percentage__", stats[3]);
+            .replace("__unlocked__", unlocked)
+            .replace("__total__", total)
+            .replace("__percentage__", percentage);
+
+        // Build "blue" style achievement bars even for games with leaderboards because the text display for these are broken
+        if (altStyle) {
+
+            // https://github.com/SteamDatabase/SteamTracking/blob/e28569b5b42106480144818c8b41cb729d61e22e/steamcommunity.com/public/javascript/profile_gameslist_functions.js#L239-L240
+            const achBarWidth = 185 * (unlocked / total);
+            const achBarWidthRemainder = 185 - achBarWidth;
+
+            return `<div class="recentAchievements">
+                ${achievementStr}
+                <br>
+                <img src="https://community.cloudflare.steamstatic.com/public/images/skin_1/achieveBarLeft.gif" width="2" height="12" border="0">
+                <img src="https://community.cloudflare.steamstatic.com/public/images/skin_1/achieveBarFull.gif" width="${achBarWidth}" height="12" border="0">
+                <img src="https://community.cloudflare.steamstatic.com/public/images/skin_1/achieveBarEmpty.gif" width="${achBarWidthRemainder}" height="12" border="0">
+                <img src="https://community.cloudflare.steamstatic.com/public/images/skin_1/achieveBarRight.gif" width="2" height="12" border="0">
+                <br>
+            </div>`.replace(/>\s+</g, "><"); // Remove whitespace between tags to avoid layout issues
+        }
 
         return `<div>${achievementStr}</div>
-                <div class="achieveBar">
-                    <div style="width: ${stats[3]}%;" class="achieveBarProgress"></div>
-                </div>`;
-    }
-
-    static async getAchievementBarForGamelist(path, appid) {
-
-        const html = await Background.action("stats", path, appid);
-        const dummy = HTMLParser.htmlToDOM(html);
-        const achNode = dummy.querySelector("#topSummaryAchievements");
-
-        if (!achNode) { return null; }
-
-        achNode.style.whiteSpace = "nowrap";
-
-        const stats = achNode.innerText.match(/(\d+)\D+(\d+)\D+(\d{1,3})%/);
-
-        // 1 full match, 3 group matches
-        if (!stats || stats.length !== 4) {
-            return null;
-        }
-
-        const achievementStr = Localization.str.achievements.summary
-            .replace("__unlocked__", stats[1])
-            .replace("__total__", stats[2])
-            .replace("__percentage__", stats[3]);
-
-        /*
-         * https://github.com/SteamDatabase/SteamTracking/blob/master/steamcommunity.com/public/javascript/profile_gameslist_functions.js#L216-L217
-         * For some reason some games report 0 total achievements, check for NaN
-         */
-        const achBarWidth = 185 * (stats[1] / stats[2]) || 0;
-        const achBarWidthRemainder = 185 - achBarWidth;
-
-        return `<div class="recentAchievements">
-            ${achievementStr}
-            <br>
-            <img src="https://community.cloudflare.steamstatic.com/public/images/skin_1/achieveBarLeft.gif" width="2" height="12" border="0">
-            <img src="https://community.cloudflare.steamstatic.com/public/images/skin_1/achieveBarFull.gif" width="${achBarWidth}" height="12" border="0">
-            <img src="https://community.cloudflare.steamstatic.com/public/images/skin_1/achieveBarEmpty.gif" width="${achBarWidthRemainder}" height="12" border="0">
-            <img src="https://community.cloudflare.steamstatic.com/public/images/skin_1/achieveBarRight.gif" width="2" height="12" border="0">
-            <br>
-        </div>`.replace(/>\s+</g, "><"); // Remove whitespace between tags to avoid layout issues
+            <div class="achieveBar">
+                <div style="width: ${percentage}%;" class="achieveBarProgress"></div>
+            </div>`;
     }
 }
 


### PR DESCRIPTION
Fixes the text display for locales which display total count before unlocked count, and which place the % sign differently.

For posterity: we could use the new method like #1470 to get the `g_rgAchievements` object, which will be much cleaner, but we use the appid to query stats pages, and sadly some games will redirect to a url with the app name, causing query parameters to be erased. For these games we'll need to do 2 fetches, which will slow down the whole process.