### PR TITLE
Simplify matching string variables in scripts

### DIFF
--- a/src/js/Content/Modules/User.js
+++ b/src/js/Content/Modules/User.js
@@ -61,16 +61,10 @@ class User {
                 if (window.location.hostname.endsWith("steampowered.com")) {
 
                     // Search through all scripts in case the order gets changed or a new one gets added
-                    for (const script of document.getElementsByTagName("script")) {
-                        const match = script.textContent.match(/GDynamicStore\.Init\(.+?, '([A-Z]{2})/);
-                        if (match) {
-                            newCountry = match[1];
-                            break;
-                        }
-                    }
+                    newCountry = HTMLParser.getVariableFromDom(/GDynamicStore\.Init\(.+?,\s*'([A-Z]{2})'/, "string");
 
                 } else if (window.location.hostname === "steamcommunity.com") {
-                    const config = document.querySelector("#webui_config,#application_config");
+                    const config = document.querySelector("#webui_config, #application_config");
                     if (config) {
                         newCountry = JSON.parse(config.dataset.config).COUNTRY;
                     }

--- a/src/js/Core/Html/HtmlParser.js
+++ b/src/js/Core/Html/HtmlParser.js
@@ -16,22 +16,26 @@ class HTMLParser {
 
     static getVariableFromText(text, name, type) {
         let regex;
-        if (type === "object") {
-            regex = new RegExp(`${name}\\s*=\\s*(\\{.+?\\});`);
-        } else if (type === "array") {
-            regex = new RegExp(`${name}\\s*=\\s*(\\[.+?\\]);`);
-        } else if (type === "int") {
-            regex = new RegExp(`${name}\\s*=\\s*(.+?);`);
-        } else if (type === "string") {
-            regex = new RegExp(`${name}\\s*=\\s*(\\".+?\\");`);
-        } else {
-            regex = new RegExp(name);
+        if (typeof name === "string") {
+            if (type === "object") {
+                regex = new RegExp(`${name}\\s*=\\s*(\\{.+?\\});`);
+            } else if (type === "array") {
+                regex = new RegExp(`${name}\\s*=\\s*(\\[.+?\\]);`);
+            } else if (type === "int") {
+                regex = new RegExp(`${name}\\s*=\\s*(.+?);`);
+            } else if (type === "string") {
+                regex = new RegExp(`${name}\\s*=\\s*['"](.+?)['"];`);
+            }
+        } else if (name instanceof RegExp) {
+            regex = name;
         }
 
         const m = text.match(regex);
         if (m) {
             if (type === "int") {
                 return parseInt(m[1]);
+            } else if (type === "string") {
+                return m[1];
             }
 
             try {


### PR DESCRIPTION
Return string variables directly instead of going through `JSON.parse`. It should work the same, and allows matching single-quoted strings too.