### PR TITLE
Refactor FHDPlayer, add feature to auto hide overlay and cursor while playing

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1031,6 +1031,10 @@ img.astats_icon {
   opacity: 1;
 }
 
+video.highlight_movie:hover + .html5_video_overlay {
+  transition: bottom 0.2s linear;
+}
+
 /***************************************
  * App pages
  * FAchievementBar

--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1025,9 +1025,10 @@ img.astats_icon {
   font-family: 'Motiva Sans', sans-serif;
   font-weight: bold;
   cursor: pointer;
-}
-.es_playback_sd .es_hd_toggle span {
   opacity: 0.4;
+}
+.es_playback_hd .es_hd_toggle {
+  opacity: 1;
 }
 
 /***************************************

--- a/src/js/Content/Features/Store/App/CApp.js
+++ b/src/js/Content/Features/Store/App/CApp.js
@@ -1,4 +1,4 @@
-import {GameId, LocalStorage, SyncedStorage} from "../../../../modulesCore";
+import {GameId, SyncedStorage} from "../../../../modulesCore";
 import {Background, ContextType, User} from "../../../modulesContent";
 import FMediaExpander from "../../Common/FMediaExpander";
 import FITADPrices from "../Common/FITADPrices";
@@ -145,6 +145,10 @@ export class CApp extends CStore {
         // FPackBreakdown skips purchase options with a package info button to avoid false positives
         FPackageInfoButton.dependencies = [FPackBreakdown];
         FPackageInfoButton.weakDependency = true;
+
+        // HDPlayer needs to wait for mp4 sources to be set
+        FHDPlayer.dependencies = [FForceMP4];
+        FHDPlayer.weakDependency = true;
     }
 
     storePageDataPromise() {
@@ -159,52 +163,41 @@ export class CApp extends CStore {
         return Background.action("itad.removefromwaitlist", this.appid);
     }
 
-    toggleVideoDefinition(videoControl, setHD) {
-        let videoIsHD = false;
+    /**
+     * @param videoEl - the video element
+     * @param {boolean} setHD - set HD or SD source
+     * @param {boolean} [force] - force set source, only current use is in FForceMP4, where we need to set mp4 source regardless of HD
+     */
+    toggleVideoDefinition(videoEl, setHD, force = false) {
+        const container = videoEl.parentNode;
+        container.classList.toggle("es_playback_hd", setHD);
 
-        const videoIsVisible = videoControl.parentNode.offsetHeight > 0 && videoControl.parentNode.offsetWidth > 0,
-            loadedSrc = videoControl.classList.contains("es_loaded_src"),
-            playInHD = LocalStorage.get("playback_hd") || videoControl.classList.contains("es_video_hd");
+        // Return early if there's nothing to do, i.e. setting HD while the video is already in HD, and vice versa
+        const isHD = videoEl.src === videoEl.dataset.hdSrc;
+        if (!force && (setHD === isHD)) { return; }
 
-        const videoPosition = videoControl.currentTime || 0,
-            videoPaused = videoControl.paused;
+        const useWebM = /\.webm/.test(videoEl.dataset.hdSrc); // `false` if browser doesn't support webm, or if "force mp4" feature is enabled
+        const isVisible = container.offsetHeight > 0 && container.offsetWidth > 0;
 
-        /** @this {HTMLVideoElement} The video element */
-        function onLoadedMetaData() {
-            this.currentTime = videoPosition;
-            if (!videoPaused && videoControl.play) {
+        // https://github.com/SteamDatabase/SteamTracking/blob/4da99e29581ba6628ad5ce24c50856703aea71a2/store.steampowered.com/public/javascript/gamehighlightplayer.js#L1055-L1067
+        const position = videoEl.currentTime || 0;
+        videoEl.pause();
+        videoEl.preload = "metadata";
 
-                Promise.resolve(videoControl.play()).catch(() => {
-                    // FIXME Why?
+        videoEl.addEventListener("loadedmetadata", () => {
+            videoEl.currentTime = position;
 
-                    // If response is a promise, suppress any errors it throws
-                });
+            if (isVisible) {
+                videoEl.play();
             }
-            videoControl.removeEventListener("loadedmetadata", onLoadedMetaData, false);
+        }, {"once": true});
+
+        if (setHD) {
+            videoEl.src = useWebM ? container.dataset.webmHdSource : container.dataset.mp4HdSource;
+        } else {
+            videoEl.src = useWebM ? container.dataset.webmSource : container.dataset.mp4Source;
         }
 
-        if (videoIsVisible) {
-            videoControl.preload = "metadata";
-            videoControl.addEventListener("loadedmetadata", onLoadedMetaData, false);
-        }
-
-        if ((!playInHD && typeof setHD === "undefined") || setHD === true) {
-            videoIsHD = true;
-            videoControl.src = videoControl.dataset.hdSrc;
-        } else if (loadedSrc) {
-            videoControl.src = videoControl.dataset.sdSrc;
-        }
-
-        if (videoIsVisible && loadedSrc) {
-            videoControl.load();
-        }
-
-        videoControl.classList.add("es_loaded_src");
-        videoControl.classList.toggle("es_video_sd", !videoIsHD);
-        videoControl.classList.toggle("es_video_hd", videoIsHD);
-        videoControl.parentNode.classList.toggle("es_playback_sd", !videoIsHD);
-        videoControl.parentNode.classList.toggle("es_playback_hd", videoIsHD);
-
-        return videoIsHD;
+        videoEl.load();
     }
 }

--- a/src/js/Content/Features/Store/App/FForceMP4.js
+++ b/src/js/Content/Features/Store/App/FForceMP4.js
@@ -1,12 +1,16 @@
+import {LocalStorage, SyncedStorage} from "../../../../modulesCore";
 import {Feature} from "../../../Modules/Feature/Feature";
-import {SyncedStorage} from "../../../../Core/Storage/SyncedStorage";
 
 export default class FForceMP4 extends Feature {
+
     checkPrerequisites() {
         return SyncedStorage.get("mp4video");
     }
 
     apply() {
+
+        const playInHD = LocalStorage.get("playback_hd");
+
         for (const node of document.querySelectorAll("[data-webm-source]")) {
             const mp4 = node.dataset.mp4Source;
             const mp4hd = node.dataset.mp4HdSource;
@@ -15,12 +19,11 @@ export default class FForceMP4 extends Feature {
             node.dataset.webmSource = mp4;
             node.dataset.webmHdSource = mp4hd;
 
-            const video = node.querySelector("video");
-            if (!video) { continue; }
+            const videoEl = node.querySelector("video");
+            if (!videoEl) { continue; }
 
-            video.dataset.sdSrc = mp4;
-            video.dataset.hdSrc = mp4hd;
-            this.context.toggleVideoDefinition(video, false);
+            videoEl.dataset.hdSrc = mp4hd;
+            this.context.toggleVideoDefinition(videoEl, playInHD, true);
         }
     }
 }

--- a/src/js/Content/Features/Store/App/FFullscreenScreenshotView.js
+++ b/src/js/Content/Features/Store/App/FFullscreenScreenshotView.js
@@ -1,11 +1,11 @@
-import {Feature} from "../../../Modules/Feature/Feature";
 import {HTML} from "../../../../modulesCore";
+import {Feature} from "../../../Modules/Feature/Feature";
 
 export default class FFullscreenScreenshotView extends Feature {
 
     apply() {
 
-        function toggleFullScreen(ev) {
+        function toggleFullscreen(ev) {
             if (document.fullscreenElement) {
                 document.exitFullscreen();
             } else {
@@ -25,9 +25,9 @@ export default class FFullscreenScreenshotView extends Feature {
             HTML.beforeEnd(modalFooter,
                 `<div class="btnv6_blue_hoverfade btn_medium es_screenshot_fullscreen_toggle" style="right: calc(${nextButtonOffsetWidth}px + 0.5em)"><i></i></div>`);
             const fsvButton = modalFooter.querySelector(".es_screenshot_fullscreen_toggle");
-            fsvButton.addEventListener("click", toggleFullScreen);
+            fsvButton.addEventListener("click", toggleFullscreen);
 
-            const modalTitleLink = modalFooter.parentElement.querySelector(".screenshot_popup_modal_title > a");
+            const modalTitleLink = modalFooter.parentNode.querySelector(".screenshot_popup_modal_title > a");
             HTML.beforeEnd(modalFooter,
                 `<div class="btnv6_blue_hoverfade btn_medium es_screenshot_open_btn" style="right: calc(${nextButtonOffsetWidth + fsvButton.offsetWidth}px + 1em)"><i></i></div>`);
             const openButton = modalFooter.querySelector(".es_screenshot_open_btn");
@@ -36,15 +36,15 @@ export default class FFullscreenScreenshotView extends Feature {
             });
         }
 
-        const observer = new MutationObserver(mutations => {
-            for (const mutation of mutations) {
-                for (const node of mutation.addedNodes) {
+        new MutationObserver(mutations => {
+            for (const {addedNodes} of mutations) {
+                for (const node of addedNodes) {
                     if (node.classList.contains("screenshot_popup_modal")) {
                         initFSVButtons();
+                        break;
                     }
                 }
             }
-        });
-        observer.observe(document.body, {"childList": true});
+        }).observe(document.body, {"childList": true});
     }
 }

--- a/src/js/Content/Features/Store/App/FHDPlayer.js
+++ b/src/js/Content/Features/Store/App/FHDPlayer.js
@@ -1,4 +1,4 @@
-import {LocalStorage} from "../../../../modulesCore";
+import {LocalStorage, TimeUtils} from "../../../../modulesCore";
 import {Feature} from "../../../Modules/Feature/Feature";
 
 export default class FHDPlayer extends Feature {
@@ -39,6 +39,28 @@ export default class FHDPlayer extends Feature {
             context.toggleVideoDefinition(videoEl, LocalStorage.get("playback_hd"));
         }
 
+        function addMouseMoveHandler(videoEl) {
+            const overlay = videoEl.nextElementSibling;
+            let timer;
+
+            videoEl.addEventListener("mousemove", () => {
+                if (timer) {
+                    timer.reset();
+                    overlay.style.bottom = "0px";
+                    videoEl.style.cursor = "";
+                } else {
+                    timer = TimeUtils.resettableTimer(() => {
+                        overlay.style.bottom = "-35px";
+                        videoEl.style.cursor = "none";
+                    }, 2000);
+                }
+            });
+
+            videoEl.addEventListener("mouseleave", () => {
+                timer?.stop(); // Avoid hiding the overlay when moving the cursor from video to overlay
+            });
+        }
+
         // Add HD Control to each video as it's added to the DOM
         for (const container of document.querySelectorAll("div.highlight_movie")) {
 
@@ -46,6 +68,7 @@ export default class FHDPlayer extends Feature {
             const videoEl = container.querySelector("video");
             if (videoEl !== null) {
                 addHDControl(videoEl);
+                addMouseMoveHandler(videoEl);
                 continue;
             }
 
@@ -58,6 +81,7 @@ export default class FHDPlayer extends Feature {
                     for (const node of addedNodes) {
                         if (node instanceof HTMLVideoElement) {
                             addHDControl(node);
+                            addMouseMoveHandler(node);
                             break;
                         }
                     }

--- a/src/js/Core/Utils/TimeUtils.js
+++ b/src/js/Core/Utils/TimeUtils.js
@@ -43,6 +43,14 @@ class ResettableTimer {
 
         this._running = true;
     }
+
+    stop() {
+        if (typeof this._id !== "undefined") {
+            clearTimeout(this._id);
+        }
+
+        this._running = false;
+    }
 }
 
 class TimeUtils {


### PR DESCRIPTION
Simplifed a bunch of stuff, fixed the case when switching from HD back to SD reloads the video (there is no `data-sd-src` attribute on videos, so we were setting the `src` to `undefined` and triggering the `onerror` handler), and removed 2 surprising behaviors I don't think makes sense
1. Override Valve's auto switch to HD when putting a video in fullscreen
2. When the slider is expanded first time after the page was loaded set videos definition to HD

Also added the feature to auto hide overlay and cursor while the video is playing. Mainly useful in fullscreen, but it works in normal view as well.

Issues remaining:
1. If autoplay and HD are enabled, the video will be paused, with an error `DOMException: play() failed because the user didn't interact with the document first`. A possible workaround is to mute the video before playing, but I'm not sure if this is desirable or if there're better ways.
2. Overlay animation might look weird when moving the mouse from outside to the video, presumably because of our added transition styles.