### PR TITLE
Omit credentials when fetching the package details endpoint

### DIFF
--- a/src/js/Content/Features/Store/Common/FRegionalPricing.js
+++ b/src/js/Content/Features/Store/Common/FRegionalPricing.js
@@ -43,7 +43,8 @@ export default class FRegionalPricing extends Feature {
 
             await Promise.all(countries.map(async country => {
                 const result = await RequestData.getJson(
-                    `https://store.steampowered.com/api/packagedetails/?packageids=${subid}&cc=${country}`
+                    `https://store.steampowered.com/api/packagedetails/?packageids=${subid}&cc=${country}`,
+                    {"credentials": "omit"}
                 );
 
                 if (!result || !result[subid] || !result[subid].success || !result[subid].data.price) { return; }


### PR DESCRIPTION
This endpoint works without sending cookies, and omitting them should fix the issue with Steam throwing HTTP 400 some people have been reporting.

Closes #1499.