### PR TITLE
Allow Chrome devtools to access source maps

### DIFF
--- a/config/manifests/chrome.json
+++ b/config/manifests/chrome.json
@@ -2,5 +2,8 @@
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgSsjOO0ecqqAz6LCjjIoiRUV3VyW4p7mmTg9bC9uUkj28OgVr5+NRJpyI8gJx7Nd43ZEQ8dfwOl8GLnc3+m90jPSUASlliWxG2LQt81IZhtFurCLUELGIfUSr5vPdthRbwgnPrmRc5nylstBORBwYtT0Dos9pBcikHn0QKo87ggWEAQEBGkLXQ8An01LnQopLX4VbZHTfvoTIjPZOiHUVhKhn4aKM70e/u61mGMSp9WDBYrV0/OFKsVC9jWd9s0DX/uOm3KpFhOj4Bx+ehzEklXNuTTQshIC7NSgh+tAJwSa1GpO9jcCWCnFRqjfxwOrdylqIvCy+87fpU7nJ6sHRQIDAQAB",
   "optional_permissions": [
     "contextMenus"
+  ],
+  "web_accessible_resources": [
+    "*.map"
   ]
 }


### PR DESCRIPTION
Without this, source map urls get blocked with `System error: net::ERR_BLOCKED_BY_CLIENT` on Chrome in production mode. Works fine on Firefox so only add to the manifest for Chrome.