### PR TITLE
Improve quick sell error handling

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -796,18 +796,30 @@ img.astats_icon {
 
 /***************************************
  * User Inventory
- * Quicksell/instantsell action buttons
+ * FQuickSellOptions
  **************************************/
-.item_market_actions a.item_market_action_button {
+/**
+ * We need higher precedence to override the display property of .item_market_action_button
+ * https://github.com/SteamDatabase/SteamTracking/blob/9868c2d72e43193c6db4530a9b3842af63563fd7/steamcommunity.com/public/css/skin_1/economy.css#L944
+ */
+.item_market_actions .item_market_action_button {
   margin-bottom: 4px;
   overflow: hidden;
   width: max-content;
   display: block;
 }
+.item_market_actions .item_market_action_button[id^=es_],
+.es_qsell_loading {
+  display: none;
+}
+.view_inventory_page .item.btn_disabled,
+.item_market_actions .item_market_action_button.btn_disabled {
+  pointer-events: none;
+}
 
 /***************************************
  * User Inventory
- * addPriceToGifts()
+ * FAddPriceToGifts
  **************************************/
 .es_game_purchase_action {
   margin-bottom: 16px;

--- a/src/js/Content/Features/Community/Inventory/CInventory.js
+++ b/src/js/Content/Features/Community/Inventory/CInventory.js
@@ -70,6 +70,7 @@ export class CInventory extends CCommunityBase {
                     "view": iActiveSelectView,
                     "sessionId": g_sessionID,
                     "marketAllowed": g_bMarketAllowed,
+                    "country": g_strCountryCode,
                     "assetId": g_ActiveInventory.selectedItem.assetid, // DO NOT try to convert this to a number as the value might exceed Number.MAX_SAFE_INTEGER
                     contextId,
                     globalId,

--- a/src/js/Content/Features/Community/Inventory/CInventory.js
+++ b/src/js/Content/Features/Community/Inventory/CInventory.js
@@ -69,6 +69,7 @@ export class CInventory extends CCommunityBase {
                 window.Messenger.postMessage("marketInfo", {
                     "view": iActiveSelectView,
                     "sessionId": g_sessionID,
+                    "marketAllowed": g_bMarketAllowed,
                     "assetId": g_ActiveInventory.selectedItem.assetid, // DO NOT try to convert this to a number as the value might exceed Number.MAX_SAFE_INTEGER
                     contextId,
                     globalId,

--- a/src/js/Content/Features/Community/Inventory/CInventory.js
+++ b/src/js/Content/Features/Community/Inventory/CInventory.js
@@ -13,8 +13,9 @@ import {Page} from "../../Page";
 export class CInventory extends CCommunityBase {
 
     constructor() {
+
         // Don't apply features on empty or private inventories
-        if (document.getElementById("no_inventories")) {
+        if (document.getElementById("no_inventories") !== null) {
             super(ContextType.INVENTORY);
             return;
         }
@@ -33,31 +34,33 @@ export class CInventory extends CCommunityBase {
         this.myInventory = CommunityUtils.currentUserIsOwner();
 
         Page.runInPageContext(() => {
-
-            /* eslint-disable no-undef, camelcase */
             document.addEventListener("click", ({target}) => {
                 if (!target.matches("a.inventory_item_link, a.newitem")) { return; }
 
+                const f = window.SteamFacade;
+                const g = f.global;
+
+                const inv = g("g_ActiveInventory");
+                const wallet = g("g_rgWalletInfo");
+                const item = inv.selectedItem;
+
                 // https://github.com/SteamDatabase/SteamTracking/blob/b3abe9c82f9e9d260265591320cac6304e500e58/steamcommunity.com/public/javascript/economy_common.js#L161
-                const hashName = window.SteamFacade.getMarketHashName(g_ActiveInventory.selectedItem.description);
+                const hashName = f.getMarketHashName(item.description);
 
                 /*
                  * See https://github.com/IsThereAnyDeal/AugmentedSteam/pull/1047#discussion_r571444376
                  * Update: For non-Steam items, the text may not have a color, so test date only
                  */
-                const restriction = Array.isArray(g_ActiveInventory.selectedItem.description.owner_descriptions)
-                    ? g_ActiveInventory.selectedItem.description.owner_descriptions.some(el => /\[date\]\d+\[\/date\]/.test(el.value))
-                    : false;
+                const restriction = Array.isArray(item.description.owner_descriptions)
+                    && item.description.owner_descriptions.some(desc => /\[date\]\d+\[\/date\]/.test(desc.value));
 
                 // https://github.com/SteamDatabase/SteamTracking/blob/f26cfc1ec42b8a0c27ca11f4343edbd8dd293255/steamcommunity.com/public/javascript/economy_v2.js#L4468
-                const publisherFee = (typeof g_ActiveInventory.selectedItem.description.market_fee !== "undefined" && g_ActiveInventory.selectedItem.description.market_fee !== null)
-                    ? g_ActiveInventory.selectedItem.description.market_fee
-                    : g_rgWalletInfo.wallet_publisher_fee_percent_default;
+                const publisherFee = item.description.market_fee ?? wallet.wallet_publisher_fee_percent_default;
 
-                const contextId = Number(g_ActiveInventory.selectedItem.contextid);
-                const globalId = Number(g_ActiveInventory.appid);
+                const contextId = Number(item.contextid);
+                const globalId = Number(inv.appid);
 
-                let appid = null;
+                let appid = 0;
                 let isBooster = false;
 
                 // Only parse hashname if the item is a Steam item
@@ -67,15 +70,15 @@ export class CInventory extends CCommunityBase {
                 }
 
                 window.Messenger.postMessage("marketInfo", {
-                    "view": iActiveSelectView,
-                    "sessionId": g_sessionID,
-                    "marketAllowed": g_bMarketAllowed,
-                    "country": g_strCountryCode,
-                    "assetId": g_ActiveInventory.selectedItem.assetid, // DO NOT try to convert this to a number as the value might exceed Number.MAX_SAFE_INTEGER
+                    "view": g("iActiveSelectView"),
+                    "sessionId": g("g_sessionID"),
+                    "marketAllowed": g("g_bMarketAllowed"),
+                    "country": g("g_strCountryCode"),
+                    "assetId": item.assetid, // DO NOT cast this to a number as the value might exceed Number.MAX_SAFE_INTEGER
                     contextId,
                     globalId,
-                    "walletCurrency": g_rgWalletInfo.wallet_currency,
-                    "marketable": g_ActiveInventory.selectedItem.description.marketable,
+                    "walletCurrency": wallet.wallet_currency,
+                    "marketable": item.description.marketable,
                     hashName,
                     publisherFee,
                     restriction,
@@ -83,7 +86,6 @@ export class CInventory extends CCommunityBase {
                     isBooster,
                 });
             });
-            /* eslint-enable no-undef, camelcase */
         });
 
         Messenger.addMessageListener("marketInfo", info => { this.triggerCallbacks(info); });

--- a/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
+++ b/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
@@ -11,6 +11,7 @@ export default class FQuickSellOptions extends CallbackFeature {
     async callback({
         view,
         sessionId,
+        marketAllowed,
         assetId,
         contextId,
         globalId,
@@ -20,7 +21,8 @@ export default class FQuickSellOptions extends CallbackFeature {
         publisherFee
     }) {
 
-        if (!marketable) { return; }
+        // Additional checks for market eligibility, see https://github.com/SteamDatabase/SteamTracking/blob/13e4e0c8f8772ef316f73881af8c546218cf7117/steamcommunity.com/public/javascript/economy_v2.js#L3675
+        if (!marketAllowed || (walletCurrency === 0) || !marketable) { return; }
 
         const thisItem = document.getElementById(`${globalId}_${contextId}_${assetId}`);
         const marketActions = document.getElementById(`iteminfo${view}_item_market_actions`);

--- a/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
+++ b/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
@@ -30,9 +30,19 @@ export default class FQuickSellOptions extends CallbackFeature {
 
         // marketActions' innerHTML is cleared on item selection, so the links HTML has to be re-inserted
         HTML.beforeEnd(marketActions,
-            this._makeMarketButton(`es_quicksell${view}`, Localization.str.quick_sell_desc.replace("__modifier__", diff))
-            + this._makeMarketButton(`es_instantsell${view}`, Localization.str.instant_sell_desc)
-            + '<div class="es_qsell_loading"></div>');
+            `<a class="item_market_action_button item_market_action_button_green" id="es_quicksell${view}" data-tooltip-text="${Localization.str.quick_sell_desc.replace("__modifier__", diff)}" style="display: none;">
+                <span class="item_market_action_button_edge item_market_action_button_left"></span>
+                <span class="item_market_action_button_contents"></span>
+                <span class="item_market_action_button_edge item_market_action_button_right"></span>
+                <span class="item_market_action_button_preload"></span>
+            </a>
+            <a class="item_market_action_button item_market_action_button_green" id="es_instantsell${view}" data-tooltip-text="${Localization.str.instant_sell_desc}" style="display: none;">
+                <span class="item_market_action_button_edge item_market_action_button_left"></span>
+                <span class="item_market_action_button_contents"></span>
+                <span class="item_market_action_button_edge item_market_action_button_right"></span>
+                <span class="item_market_action_button_preload"></span>
+            </a>
+            <div class="es_qsell_loading"></div>`);
 
         Page.runInPageContext(view => {
             window.SteamFacade.vTooltip(`#es_quicksell${view}, #es_instantsell${view}`);
@@ -170,14 +180,5 @@ export default class FQuickSellOptions extends CallbackFeature {
                 dataset.priceHigh = priceHigh.toFixed(2) * 100;
             }
         }
-    }
-
-    _makeMarketButton(id, tooltip) {
-        return `<a class="item_market_action_button item_market_action_button_green" id="${id}" data-tooltip-text="${tooltip}" style="display: none;">
-                    <span class="item_market_action_button_edge item_market_action_button_left"></span>
-                    <span class="item_market_action_button_contents"></span>
-                    <span class="item_market_action_button_edge item_market_action_button_right"></span>
-                    <span class="item_market_action_button_preload"></span>
-                </a>`;
     }
 }

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -117,6 +117,7 @@
     "quick_sell_desc": "Price difference of __modifier__ compared to the price of the cheapest offer currently listed on the Steam Market",
     "instant_sell": "Instant Sell for __amount__",
     "instant_sell_desc": "The price of the highest buy order currently listed on the Steam Market",
+    "quick_sell_verify": "Steam Guard confirmation needed",
     "starting_at": "Starting at: __price__",
     "hardwareads": "Hardware Advertising",
     "homepage_tabs": "Homepage Tabs",


### PR DESCRIPTION
Display error message if listing an item failed (or endpoint threw) or requires Steam Guard confirmation (there're different messages for mobile and email auth, but we'll just show a generic message since I believe users are capable of figuring it out themselves).

Refactor getting market prices (related to #1513):
1. Add "country" parameter to the market/itemordershistogram endpoint. Seems to help with avoiding 429s.
2. Cache market prices to reduce requests for duplicate items.
3. Better error logging and added TODOs