### PR TITLE
Remove group row after leaving instead of setting opacity

### DIFF
--- a/src/js/Content/Features/Community/FriendsAndGroups/FGroupsManageButton.js
+++ b/src/js/Content/Features/Community/FriendsAndGroups/FGroupsManageButton.js
@@ -36,13 +36,14 @@ export default class FGroupsManageButton extends CallbackFeature {
                     </span>
                 </div>
                 <div class="row">
-                    <span class="manage_action anage_action btnv6_lightblue_blue btn_medium btn_uppercase" id="es_leave_groups">
-                        <span>${groupsStr.leave}</span>
-                    </span>
+                    <div class="manage_friend_actions_ctn">
+                        <span class="manage_action btnv6_lightblue_blue btn_small" id="es_leave_groups">
+                            <span>${groupsStr.leave}</span>
+                        </span>
+                    </div>
                     <span id="selected_msg_err" class="selected_msg error hidden"></span>
                     <span id="selected_msg" class="selected_msg hidden">${groupsStr.selected.replace("__n__", '<span id="selected_count"></span>')}</span>
                 </div>
-                <div class="row"></div>
             </div>`);
 
         for (const group of groups) {

--- a/src/js/Content/Features/Community/FriendsAndGroups/FGroupsManageButton.js
+++ b/src/js/Content/Features/Community/FriendsAndGroups/FGroupsManageButton.js
@@ -15,8 +15,8 @@ export default class FGroupsManageButton extends CallbackFeature {
     callback() {
         if (!document.getElementById("groups_list")) { return; }
 
-        this._groups = Array.from(document.querySelectorAll(".group_block"));
-        if (this._groups.length === 0) { return; }
+        const groups = document.querySelectorAll(".group_block");
+        if (groups.length === 0) { return; }
 
         const groupsStr = Localization.str.groups;
 
@@ -45,7 +45,7 @@ export default class FGroupsManageButton extends CallbackFeature {
                 <div class="row"></div>
             </div>`);
 
-        for (const group of this._groups) {
+        for (const group of groups) {
             group.classList.add("selectable");
             HTML.afterBegin(group,
                 `<div class="indicator select_friend">
@@ -81,10 +81,7 @@ export default class FGroupsManageButton extends CallbackFeature {
     async _leaveGroups() {
         const selected = [];
 
-        for (const group of this._groups) {
-            if (!group.classList.contains("selected")) {
-                continue;
-            }
+        for (const group of document.querySelectorAll(".group_block.selected")) {
 
             const actions = group.querySelector(".actions");
             const admin = actions.querySelector("[href*='/edit']");
@@ -121,8 +118,8 @@ export default class FGroupsManageButton extends CallbackFeature {
                         continue;
                     }
 
-                    group.style.opacity = "0.3";
-                    group.querySelector(".select_friend").click();
+                    // Make sure to remove the row so it doesn't show up again when filtering
+                    group.remove();
                 }
             }
         }

--- a/src/js/Content/Features/Community/FriendsAndGroups/FInviteFriendsToGroup.js
+++ b/src/js/Content/Features/Community/FriendsAndGroups/FInviteFriendsToGroup.js
@@ -15,8 +15,8 @@ export default class FInviteButton extends CallbackFeature {
     callback() {
         if (!document.getElementById("friends_list")) { return; }
 
-        HTML.afterBegin("#manage_friends > div:nth-child(2)",
-            `<span class="manage_action btnv6_lightblue_blue btn_medium" id="invitetogroup">
+        HTML.beforeEnd(".manage_friend_actions_ctn",
+            `<span class="manage_action btnv6_lightblue_blue btn_small" id="es_invite_to_group">
                 <span>${Localization.str.invite_to_group}</span>
             </span>`);
 
@@ -27,13 +27,13 @@ export default class FInviteButton extends CallbackFeature {
             Page.runInPageContext(groupId => {
                 const f = window.SteamFacade;
                 f.toggleManageFriends();
-                f.jqOnClick("#invitetogroup", () => {
+                f.jqOnClick("#es_invite_to_group", () => {
                     const friends = f.getCheckedAccounts("#search_results > .selectable.selected:visible");
                     f.inviteUserToGroup(null, groupId, friends);
                 });
             }, [params.get("invitegid")]);
         } else {
-            document.getElementById("invitetogroup").addEventListener("click", () => {
+            document.getElementById("es_invite_to_group").addEventListener("click", () => {
                 Page.runInPageContext(() => { window.SteamFacade.execFriendAction("group_invite", "friends/all"); });
             });
         }


### PR DESCRIPTION
Feels weird that the links are still clickable afterwards, so just remove the entire row.

On a side note, we shouldn't be setting the display either, because otherwise the row will show up again when filtering by keywords. Steam's native "leave group" action has this bug. Dunno if it's worth fixing, but at least make it work better for our feature.