### PR TITLE
Improve community EA banners and tweak image sizes

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1697,7 +1697,7 @@ video.highlight_movie:hover + .html5_video_overlay {
 .home_content_item .es_overlay_container,
 .small_cap .es_overlay_container,
 .special.special_img_ctn .es_overlay_container,
-.leftcol .es_overlay_container,
+.game_capsule_ctn .es_overlay_container,
 .review_app_actions .gameLogoHolder_default .es_overlay_container {
   position: relative;
   display: inherit;
@@ -1710,6 +1710,13 @@ video.highlight_movie:hover + .html5_video_overlay {
 }
 .curator_featured .es_overlay {
   height: 25%;
+}
+.gameListRowLogo .es_overlay,
+.game_capsule_ctn .es_overlay {
+  height: 70%;
+}
+.gameLogo .es_overlay {
+  height: 50%;
 }
 .tab_item.es_early_access > .tab_item_cap {
   line-height: 48px;

--- a/src/js/Content/Features/Common/FEarlyAccess.js
+++ b/src/js/Content/Features/Common/FEarlyAccess.js
@@ -104,8 +104,7 @@ export default class FEarlyAccess extends Feature {
 }
 
 // TODO support React-based sales pages, curator lists, etc.
-FEarlyAccess._selector = [
-    // Store only, selectors for the Community are split into relevant contexts
+const storeSelectors = [
     ".tab_item", // Item rows on storefront, genre, category, tags etc. pages
     ".quadscreenshot_carousel a", // Top carousel on genre, category, tags etc. pages
     ".newonsteam_headercap", // explore/new
@@ -136,5 +135,17 @@ FEarlyAccess._selector = [
     ".recommendation_carousel_item",
     ".app_header",
     ".friendplaytime_appheader",
-].map(sel => `${sel}:not(.es_ea_checked)`)
+];
+
+const communitySelectors = [
+    // Selectors for Profile Home are split out due to issues with running them on my/edit/showcases
+    ".gameListRowLogo", // my/games
+    ".gameLogo", // Various game community pages e.g. global/personal achievements
+    ".blotter_gamepurchase_logo", // activity home
+    ".gameLogoHolder_default", // activity home, individual reviews
+    ".game_capsule_ctn", // reviews list
+];
+
+FEarlyAccess._selector = (window.location.hostname === "store.steampowered.com" ? storeSelectors : communitySelectors)
+    .map(sel => `${sel}:not(.es_ea_checked)`)
     .join(",");

--- a/src/js/Content/Features/Community/CCommunityBase.js
+++ b/src/js/Content/Features/Community/CCommunityBase.js
@@ -1,4 +1,5 @@
 import {Context, ContextType} from "../../modulesContent";
+import FEarlyAccess from "../Common/FEarlyAccess";
 import FHideTrademarks from "../Common/FHideTrademarks";
 import FConfirmDeleteComment from "./FConfirmDeleteComment";
 import FHideSpamComments from "./FHideSpamComments";
@@ -9,6 +10,7 @@ export class CCommunityBase extends Context {
     constructor(type = ContextType.COMMUNITY_DEFAULT, features = []) {
 
         features.push(
+            FEarlyAccess,
             FHideTrademarks,
             FConfirmDeleteComment,
             FHideSpamComments,

--- a/src/js/Content/Features/Community/Games/CGames.js
+++ b/src/js/Content/Features/Community/Games/CGames.js
@@ -1,6 +1,5 @@
 import ContextType from "../../../Modules/Context/ContextType";
 import {CCommunityBase} from "../CCommunityBase";
-import FEarlyAccess from "../../Common/FEarlyAccess";
 import FFixAppImageNotFound from "../FFixAppImageNotFound";
 import FGamesStats from "./FGamesStats";
 import FCommonGames from "./FCommonGames";
@@ -22,8 +21,6 @@ export class CGames extends CCommunityBase {
             FCommonGames,
             FGamelistAchievements,
         ]);
-
-        FEarlyAccess.show(document.querySelectorAll(".gameListRowLogo"));
 
         this.showStats = new URLSearchParams(window.location.search).get("tab") === "all";
     }

--- a/src/js/Content/Features/Community/ProfileActivity/CProfileActivity.js
+++ b/src/js/Content/Features/Community/ProfileActivity/CProfileActivity.js
@@ -19,8 +19,6 @@ export class CProfileActivity extends CCommunityBase {
             FToggleComments,
         ]);
 
-        FEarlyAccess.show(document.querySelectorAll(".blotter_gamepurchase_logo, .gameLogoHolder_default"));
-
         this._registerObserver();
 
         // Fix undefined function when clicking on the "show all x comments" button under "uploaded a screenshot" type activity

--- a/src/js/Content/Features/Community/Recommended/CRecommended.js
+++ b/src/js/Content/Features/Community/Recommended/CRecommended.js
@@ -1,6 +1,5 @@
 import ContextType from "../../../Modules/Context/ContextType";
 import {CCommunityBase} from "../CCommunityBase";
-import FEarlyAccess from "../../Common/FEarlyAccess";
 import FReviewSort from "./FReviewSort";
 
 export class CRecommended extends CCommunityBase {
@@ -10,7 +9,5 @@ export class CRecommended extends CCommunityBase {
         super(ContextType.RECOMMENDED, [
             FReviewSort,
         ]);
-
-        FEarlyAccess.show(document.querySelectorAll(".leftcol > a, .gameLogoHolder_default"));
     }
 }


### PR DESCRIPTION
Run the feature on all community pages instead, since splitting it out to relevant contexts risks missing out on pages where we don't have specific features, e.g. global achievements page and individual reviews.