### PR TITLE
Add Cart page context and feature to show cart history link

### DIFF
--- a/config/manifests/base.json
+++ b/config/manifests/base.json
@@ -102,6 +102,10 @@
       "js": "js/store/points_shop.js"
     },
     {
+      "matches": "*://*.steampowered.com/cart[/*]",
+      "js": "js/store/cart.js"
+    },
+    {
       "matches": "*://*.steampowered.com/*",
       "exclude_matches": [
         "*://store.steampowered.com/dynamicstore/*",
@@ -129,7 +133,8 @@
         "*://*.steampowered.com/sub/*",
         "*://*.steampowered.com/app/*",
         "*://*.steampowered.com/agecheck/*",
-        "*://*.steampowered.com/points[/*]"
+        "*://*.steampowered.com/points[/*]",
+        "*://*.steampowered.com/cart[/*]"
       ],
       "js": "js/store/default.js"
     },

--- a/config/webpack/webpack.common.cjs
+++ b/config/webpack/webpack.common.cjs
@@ -46,6 +46,7 @@ module.exports = {
         "js/store/agecheck": "./src/js/Content/Features/Store/AgeCheck/PAgecheck.js",
         "js/store/app": "./src/js/Content/Features/Store/App/PApp.js",
         "js/store/bundle": "./src/js/Content/Features/Store/Bundle/PBundle.js",
+        "js/store/cart": "./src/js/Content/Features/Store/Cart/PCart.js",
         "js/store/default": "./src/js/Content/Features/Store/PDefaultStore.js",
         "js/store/frontpage": "./src/js/Content/Features/Store/Storefront/PStoreFront.js",
         "js/store/funds": "./src/js/Content/Features/Store/Funds/PFunds.js",

--- a/src/js/Content/Features/Store/Cart/CCart.js
+++ b/src/js/Content/Features/Store/Cart/CCart.js
@@ -1,0 +1,13 @@
+import ContextType from "../../../Modules/Context/ContextType";
+import {CStoreBase} from "../Common/CStoreBase";
+import FCartHistoryLink from "./FCartHistoryLink";
+
+export class CCart extends CStoreBase {
+
+    constructor() {
+
+        super(ContextType.CART, [
+            FCartHistoryLink,
+        ]);
+    }
+}

--- a/src/js/Content/Features/Store/Cart/FCartHistoryLink.js
+++ b/src/js/Content/Features/Store/Cart/FCartHistoryLink.js
@@ -1,0 +1,13 @@
+import {HTML, Localization} from "../../../../modulesCore";
+import {Feature} from "../../../modulesContent";
+
+export default class FCartHistoryLink extends Feature {
+
+    apply() {
+
+        HTML.afterEnd("h2.pageheader",
+            `<a href="https://help.steampowered.com/accountdata/ShoppingCartHistory" target="_blank">
+                ${Localization.str.shopping_cart_history}
+            </a>`);
+    }
+}

--- a/src/js/Content/Features/Store/Cart/PCart.js
+++ b/src/js/Content/Features/Store/Cart/PCart.js
@@ -1,0 +1,4 @@
+import {StorePage} from "../../StorePage";
+import {CCart} from "./CCart";
+
+(new StorePage()).run(CCart);

--- a/src/js/Content/Modules/Context/ContextType.js
+++ b/src/js/Content/Modules/Context/ContextType.js
@@ -6,7 +6,7 @@ export default Object.freeze({
     "STORE_DEFAULT": 4,
     "FUNDS": 5,
     "REGISTER_KEY": 6,
-    "SALE": 7, // unused
+    "CART": 7,
     "SEARCH": 8,
     "CHARTS": 9,
     "STORE_FRONT": 10,


### PR DESCRIPTION
Users have noted this feature is difficult to find in the account preferences page, so add it to the cart page itself. There's still the issue where if Steam empties your cart after some time of inactivity, the cart button will be hidden. But I'm not sure if it's desirable to always show the cart button (though most e-commerce sites I use are like that).

In preparation for adding features to the cart/history page: https://github.com/IsThereAnyDeal/AugmentedSteam/issues/1143#issuecomment-873598311.