### PR TITLE
Remove `HTML` methods from `HTMLParser`

### DIFF
--- a/src/js/Background/Modules/SteamStoreApi.js
+++ b/src/js/Background/Modules/SteamStoreApi.js
@@ -1,3 +1,4 @@
+import {HTML} from "../../Core/Html/Html";
 import {HTMLParser} from "../../Core/Html/HtmlParser";
 import {Errors} from "../../Core/Errors/Errors";
 import {Api} from "./Api";
@@ -63,14 +64,14 @@ class SteamStoreApi extends Api {
 
     static async currencyFromWallet() {
         const html = await SteamStoreApi.getPage("/steamaccount/addfunds");
-        const dummyPage = HTMLParser.htmlToDOM(html);
+        const dummyPage = HTML.toDom(html);
 
         return dummyPage.querySelector("input[name=currency]").value;
     }
 
     static async currencyFromApp() {
         const html = await SteamStoreApi.getPage("/app/220");
-        const dummyPage = HTMLParser.htmlToDOM(html);
+        const dummyPage = HTML.toDom(html);
 
         const currency = dummyPage.querySelector("meta[itemprop=priceCurrency][content]");
         if (!currency || !currency.getAttribute("content")) {
@@ -102,7 +103,7 @@ class SteamStoreApi extends Api {
                 throw new Errors.LoginError("store");
             }
         });
-        const dummyPage = HTMLParser.htmlToDOM(html);
+        const dummyPage = HTML.toDom(html);
 
         const node = dummyPage.querySelector("#dselect_user_country");
         return node && node.value;
@@ -141,7 +142,7 @@ class SteamStoreApi extends Api {
         const purchaseDates = new Map();
 
         const html = await SteamStoreApi.getPage("/account/licenses/", {"l": lang});
-        const dummyPage = HTMLParser.htmlToDOM(html);
+        const dummyPage = HTML.toDom(html);
         const nodes = dummyPage.querySelectorAll("#main_content td.license_date_col");
         for (const node of nodes) {
             const name = node.nextElementSibling;

--- a/src/js/Background/Modules/SteamStoreApi.js
+++ b/src/js/Background/Modules/SteamStoreApi.js
@@ -1,6 +1,7 @@
 import {HTML} from "../../Core/Html/Html";
 import {HTMLParser} from "../../Core/Html/HtmlParser";
 import {Errors} from "../../Core/Errors/Errors";
+import {StringUtils} from "../../Core/Utils/StringUtils";
 import {Api} from "./Api";
 import {IndexedDB} from "./IndexedDB";
 import {CacheStorage} from "./CacheStorage";
@@ -149,7 +150,7 @@ class SteamStoreApi extends Api {
             const removeNode = name.querySelector("div");
             if (removeNode) { removeNode.remove(); }
 
-            let appName = HTMLParser.clearSpecialSymbols(name.textContent.trim());
+            let appName = StringUtils.clearSpecialSymbols(name.textContent.trim());
             for (const regex of replaceRegex) {
                 appName = appName.replace(regex, "");
             }

--- a/src/js/Content/Features/Common/FEarlyAccess.js
+++ b/src/js/Content/Features/Common/FEarlyAccess.js
@@ -37,7 +37,7 @@ export default class FEarlyAccess extends Feature {
 
             const imageUrl = ExtensionResources.getURL(imageName);
 
-            this._container = HTML.element(
+            this._container = HTML.toElement(
                 `<span class="es_overlay_container">
                     <span class="es_overlay">
                         <img title="${Localization.str.early_access}" src="${imageUrl}">

--- a/src/js/Content/Features/Community/Badges/CBadges.js
+++ b/src/js/Content/Features/Community/Badges/CBadges.js
@@ -1,4 +1,4 @@
-import {HTMLParser} from "../../../../Core/Html/HtmlParser";
+import {HTML, HTMLParser} from "../../../../modulesCore";
 import {CommunityUtils, ContextType, DOMHelper, RequestData} from "../../../modulesContent";
 import {CCommunityBase} from "../CCommunityBase";
 import FCardExchangeLinks from "../FCardExchangeLinks";
@@ -35,7 +35,7 @@ export class CBadges extends CCommunityBase {
                 const response = await RequestData.getHttp(url.toString());
 
                 const delayedLoadImages = HTMLParser.getVariableFromText(response, "g_rgDelayedLoadImages", "object");
-                const dom = HTMLParser.htmlToDOM(response);
+                const dom = HTML.toDom(response);
 
                 await callback(dom, delayedLoadImages);
 

--- a/src/js/Content/Features/Community/Badges/FBadgeCalculations.js
+++ b/src/js/Content/Features/Community/Badges/FBadgeCalculations.js
@@ -1,4 +1,4 @@
-import {GameId, HTML, HTMLParser, Localization} from "../../../../modulesCore";
+import {GameId, HTML, Localization} from "../../../../modulesCore";
 import {Background, CurrencyManager, DOMHelper, Feature, Price, RequestData} from "../../../modulesContent";
 
 export default class FBadgeCalculations extends Feature {
@@ -180,7 +180,7 @@ export default class FBadgeCalculations extends Feature {
             return;
         }
 
-        const dummyPage = HTMLParser.htmlToDOM(response);
+        const dummyPage = HTML.toDom(response);
         const boosterCount = dummyPage.querySelectorAll(".booster_eligibility_game").length;
 
         HTML.beforeEnd("#es_calculations", `<br>${Localization.str.games_with_booster.replace("__boostergames__", boosterCount)}`);

--- a/src/js/Content/Features/Community/FriendsAndGroups/FFriendsSort.js
+++ b/src/js/Content/Features/Community/FriendsAndGroups/FFriendsSort.js
@@ -39,7 +39,7 @@ export default class FFriendsSort extends CallbackFeature {
 
             this._friendsFetched = true;
             const data = await RequestData.getHttp("https://steamcommunity.com/my/friends/?ajax=1&l=english");
-            const dom = HTMLParser.htmlToElement(data);
+            const dom = HTMLParser.htmlToDOM(data);
             const lastOnlineRegex = /Last Online (?:(\d+) days)?(?:, )?(?:(\d+) hrs)?(?:, )?(?:(\d+) mins)? ago/;
 
             for (const friend of dom.querySelectorAll(".friend_block_v2.persona.offline")) {

--- a/src/js/Content/Features/Community/FriendsAndGroups/FFriendsSort.js
+++ b/src/js/Content/Features/Community/FriendsAndGroups/FFriendsSort.js
@@ -1,4 +1,4 @@
-import {HTMLParser, Localization, SyncedStorage} from "../../../../modulesCore";
+import {HTML, Localization, SyncedStorage} from "../../../../modulesCore";
 import {CallbackFeature, RequestData, Sortbox} from "../../../modulesContent";
 
 export default class FFriendsSort extends CallbackFeature {
@@ -39,7 +39,7 @@ export default class FFriendsSort extends CallbackFeature {
 
             this._friendsFetched = true;
             const data = await RequestData.getHttp("https://steamcommunity.com/my/friends/?ajax=1&l=english");
-            const dom = HTMLParser.htmlToDOM(data);
+            const dom = HTML.toDom(data);
             const lastOnlineRegex = /Last Online (?:(\d+) days)?(?:, )?(?:(\d+) hrs)?(?:, )?(?:(\d+) mins)? ago/;
 
             for (const friend of dom.querySelectorAll(".friend_block_v2.persona.offline")) {

--- a/src/js/Content/Features/Community/MarketHome/FMarketStats.js
+++ b/src/js/Content/Features/Community/MarketHome/FMarketStats.js
@@ -1,4 +1,4 @@
-import {HTML, HTMLParser, LocalStorage, Localization, SyncedStorage, TimeUtils} from "../../../../modulesCore";
+import {HTML, LocalStorage, Localization, SyncedStorage, TimeUtils} from "../../../../modulesCore";
 import {Feature, Price, RequestData, User} from "../../../modulesContent";
 
 export default class FMarketStats extends Feature {
@@ -158,7 +158,7 @@ export default class FMarketStats extends Feature {
             }
 
             const data = await RequestData.getJson(url.toString());
-            const dom = HTMLParser.htmlToDOM(data.results_html); // TODO use DOMParser since there's no need to sanitize?
+            const dom = HTML.toDom(data.results_html); // TODO use DOMParser since there's no need to sanitize?
 
             /*
              * Request may fail with results_html === "\t\t\t\t\t\t<div class=\"market_listing_table_message\">

--- a/src/js/Content/Features/Community/ProfileActivity/FToggleComments.js
+++ b/src/js/Content/Features/Community/ProfileActivity/FToggleComments.js
@@ -4,7 +4,7 @@ import {CallbackFeature, ConfirmDialog} from "../../../modulesContent";
 export default class FToggleComments extends CallbackFeature {
 
     setup() {
-        this._btnEl = HTML.element('<span class="btn_grey_grey btn_small_thin as_comments_toggle"><span></span></span>');
+        this._btnEl = HTML.toElement('<span class="btn_grey_grey btn_small_thin as_comments_toggle"><span></span></span>');
 
         this.callback();
     }

--- a/src/js/Content/Features/Community/ProfileHome/FInGameStoreLink.js
+++ b/src/js/Content/Features/Community/ProfileHome/FInGameStoreLink.js
@@ -1,4 +1,4 @@
-import {GameId, HTML, HTMLParser, Localization} from "../../../../modulesCore";
+import {GameId, HTML, Localization} from "../../../../modulesCore";
 import {Feature, RequestData} from "../../../modulesContent";
 
 export default class FInGameStoreLink extends Feature {
@@ -17,7 +17,7 @@ export default class FInGameStoreLink extends Feature {
         // Otherwise fetch the profile's miniprofile hover content
         if (!appid) {
             const html = await RequestData.getHttp(`https://steamcommunity.com/miniprofile/${this._avatarNode.dataset.miniprofile}`);
-            const doc = HTMLParser.htmlToDOM(html);
+            const doc = HTML.toDom(html);
             appid = GameId.getAppidImgSrc(doc.querySelector("img.game_logo"));
             if (!appid) { return; }
         }

--- a/src/js/Content/Features/Community/Recommended/FReviewSort.js
+++ b/src/js/Content/Features/Community/Recommended/FReviewSort.js
@@ -1,4 +1,4 @@
-import {HTMLParser, Localization, SyncedStorage, TimeUtils} from "../../../../modulesCore";
+import {HTML, Localization, SyncedStorage, TimeUtils} from "../../../../modulesCore";
 import {Background, Feature, Messenger, Sortbox} from "../../../modulesContent";
 import {Page} from "../../Page";
 
@@ -86,7 +86,7 @@ export default class FReviewSort extends Feature {
 
             const footer = document.querySelector("#leftContents > .workshopBrowsePaging:last-child");
             for (const {node} of displayedReviews) {
-                footer.insertAdjacentElement("beforebegin", HTMLParser.htmlToElement(node));
+                HTML.beforeBegin(footer, node);
             }
 
             // Add back sanitized event handlers

--- a/src/js/Content/Features/Community/SharedFiles/FSubscribeAllDependencies.js
+++ b/src/js/Content/Features/Community/SharedFiles/FSubscribeAllDependencies.js
@@ -13,7 +13,7 @@ export default class FSubscribeAllDependencies extends Feature {
 
             if (document.querySelector(".newmodal") === null) { return; }
 
-            const subBtn = HTML.element(
+            const subBtn = HTML.toElement(
                 `<div class="btn_blue_steamui btn_medium">
                     <span>${Localization.str.workshop.subscribe_all}</span>
                 </div>`
@@ -31,7 +31,7 @@ export default class FSubscribeAllDependencies extends Feature {
                 active = true;
 
                 const items = document.querySelectorAll(".newmodal #RequiredItems > a");
-                const loader = HTML.element("<div class='loader'></div>");
+                const loader = HTML.toElement("<div class='loader'></div>");
                 const originalContainer = document.querySelector("#rightContents #RequiredItems");
                 let failed = false;
 

--- a/src/js/Content/Features/Store/App/FBadgeProgress.js
+++ b/src/js/Content/Features/Store/App/FBadgeProgress.js
@@ -1,5 +1,5 @@
 import {Background, DOMHelper, Feature, User} from "../../../modulesContent";
-import {HTML, HTMLParser, Localization, SyncedStorage} from "../../../../modulesCore";
+import {HTML, Localization, SyncedStorage} from "../../../../modulesCore";
 
 export default class FBadgeProgress extends Feature {
 
@@ -39,7 +39,7 @@ export default class FBadgeProgress extends Feature {
     }
 
     _loadBadgeContent(targetSelector, result) {
-        const dummy = HTMLParser.htmlToDOM(result);
+        const dummy = HTML.toDom(result);
 
         /*
          * grap badge and game cards

--- a/src/js/Content/Features/Store/Common/FExtraLinks.js
+++ b/src/js/Content/Features/Store/Common/FExtraLinks.js
@@ -1,4 +1,4 @@
-import {HTML, HTMLParser, Localization, SyncedStorage} from "../../../../modulesCore";
+import {HTML, Localization, StringUtils, SyncedStorage} from "../../../../modulesCore";
 import {ContextType, Feature} from "../../../modulesContent";
 
 export default class FExtraLinks extends Feature {
@@ -44,7 +44,7 @@ export default class FExtraLinks extends Feature {
     apply() {
 
         const isAppPage = this._type === "app";
-        const appName = typeof this.context.appName === "string" && HTMLParser.clearSpecialSymbols(this.context.appName);
+        const appName = typeof this.context.appName === "string" && StringUtils.clearSpecialSymbols(this.context.appName);
 
         // Note: Links should be rendered in the same order as displayed on the options page
         const links = this._getLinks(isAppPage, appName);

--- a/src/js/Content/Features/Store/Wishlist/FWishlistUserNotes.js
+++ b/src/js/Content/Features/Store/Wishlist/FWishlistUserNotes.js
@@ -10,7 +10,7 @@ export default class FWishlistUserNotes extends CallbackFeature {
 
     setup() {
         this._userNotes = new UserNotes();
-        this._noteEl = HTML.element(`<div class="esi-note esi-note--wishlist ellipsis">${Localization.str.user_note.add}</div>`);
+        this._noteEl = HTML.toElement(`<div class="esi-note esi-note--wishlist ellipsis">${Localization.str.user_note.add}</div>`);
 
         document.addEventListener("click", ({target}) => {
             if (!target.classList.contains("esi-note")) { return; }

--- a/src/js/Content/Modules/AugmentedSteam.js
+++ b/src/js/Content/Modules/AugmentedSteam.js
@@ -66,7 +66,7 @@ class AugmentedSteam {
     }
 
     static _addWarning(innerHTML, stopShowingHandler) {
-        const el = HTML.element(
+        const el = HTML.toElement(
             `<div class="es_warn js-warn">
                 <div class="es_warn__cnt">
                     <div>${innerHTML}</div>

--- a/src/js/Content/Modules/Stats.js
+++ b/src/js/Content/Modules/Stats.js
@@ -1,4 +1,4 @@
-import {HTMLParser} from "../../Core/Html/HtmlParser";
+import {HTML} from "../../Core/Html/Html";
 import {Localization} from "../../Core/Localization/Localization";
 import {Background} from "./Background";
 
@@ -7,7 +7,7 @@ class Stats {
     static async getAchievementBar(path, appid, altStyle = false) {
 
         const html = await Background.action("stats", path, appid);
-        const achNode = HTMLParser.htmlToDOM(html).querySelector("#topSummaryAchievements");
+        const achNode = HTML.toDom(html).querySelector("#topSummaryAchievements");
         if (!achNode) { return null; }
 
         // Games without leaderboards will have "grey" style achievement bars, return them

--- a/src/js/Content/Modules/User.js
+++ b/src/js/Content/Modules/User.js
@@ -1,5 +1,6 @@
 import {CookieStorage} from "../../Core/Storage/CookieStorage";
 import {HTMLParser} from "../../Core/Html/HtmlParser";
+import {StringUtils} from "../../Core/Utils/StringUtils";
 import {Background} from "./Background";
 import {RequestData} from "./RequestData";
 
@@ -101,7 +102,7 @@ class User {
     }
 
     static getPurchaseDate(lang, appName) {
-        const _appName = HTMLParser.clearSpecialSymbols(appName);
+        const _appName = StringUtils.clearSpecialSymbols(appName);
         return Background.action("purchases", _appName, lang);
     }
 

--- a/src/js/Content/Modules/Widgets/SortBox.js
+++ b/src/js/Content/Modules/Widgets/SortBox.js
@@ -127,7 +127,7 @@ class Sortbox {
         const arrowDown = "↓";
         const arrowUp = "↑";
 
-        const box = HTML.element(
+        const box = HTML.toElement(
             `<div class="es-sortbox es-sortbox--${name}">
                 <div class="es-sortbox__label">${Localization.str.sort_by}</div>
                 <div id="${id}_container" class="es-sortbox__container">

--- a/src/js/Core/Html/Html.js
+++ b/src/js/Core/Html/Html.js
@@ -76,7 +76,7 @@ class HTML {
         return _wrapper;
     }
 
-    static adjacent(node, position, html) {
+    static _adjacent(node, position, html) {
         const _node = HTML._getNode(node);
 
         if (_node) {
@@ -86,19 +86,19 @@ class HTML {
     }
 
     static beforeBegin(node, html) {
-        HTML.adjacent(node, "beforebegin", html);
+        HTML._adjacent(node, "beforebegin", html);
     }
 
     static afterBegin(node, html) {
-        HTML.adjacent(node, "afterbegin", html);
+        HTML._adjacent(node, "afterbegin", html);
     }
 
     static beforeEnd(node, html) {
-        HTML.adjacent(node, "beforeend", html);
+        HTML._adjacent(node, "beforeend", html);
     }
 
     static afterEnd(node, html) {
-        HTML.adjacent(node, "afterend", html);
+        HTML._adjacent(node, "afterend", html);
     }
 }
 

--- a/src/js/Core/Html/Html.js
+++ b/src/js/Core/Html/Html.js
@@ -28,19 +28,16 @@ class HTML {
     static _getNode(node) {
         let _node = node;
 
-        if (typeof _node == "undefined" || _node === null) {
-            console.warn(`${_node} is not an Element.`);
-            return null;
-        }
-        if (typeof _node == "string") {
+        if (typeof _node === "string") {
             _node = document.querySelector(_node);
         }
-        if (!(_node instanceof Element)) {
-            console.warn(`${_node} is not an Element.`);
-            return null;
+
+        if (_node instanceof Element) {
+            return _node;
         }
 
-        return _node;
+        console.warn(`${_node} is not an Element.`);
+        return null;
     }
 
     static inner(node, html) {

--- a/src/js/Core/Html/Html.js
+++ b/src/js/Core/Html/Html.js
@@ -21,6 +21,11 @@ class HTML {
         return template.content;
     }
 
+    // TODO deprecated, to be removed
+    static element(html) {
+        return HTML.toElement(html);
+    }
+
     static toElement(html) {
         return HTML.toDom(html).firstElementChild;
     }

--- a/src/js/Core/Html/Html.js
+++ b/src/js/Core/Html/Html.js
@@ -15,14 +15,14 @@ class HTML {
         return str.replace(/[&<>"']/g, (m) => { return map[m]; });
     }
 
-    static fragment(html) {
+    static toDom(html) {
         const template = document.createElement("template");
         template.innerHTML = DOMPurify.sanitize(html);
         return template.content;
     }
 
     static element(html) {
-        return HTML.fragment(html).firstElementChild;
+        return HTML.toDom(html).firstElementChild;
     }
 
     static _getNode(node) {

--- a/src/js/Core/Html/Html.js
+++ b/src/js/Core/Html/Html.js
@@ -21,7 +21,7 @@ class HTML {
         return template.content;
     }
 
-    static element(html) {
+    static toElement(html) {
         return HTML.toDom(html).firstElementChild;
     }
 
@@ -73,7 +73,7 @@ class HTML {
             wrappedNodes.push(cur.nextElementSibling);
         }
 
-        const _wrapper = HTML.element(wrapper);
+        const _wrapper = HTML.toElement(wrapper);
         _startEl.replaceWith(_wrapper);
         _wrapper.append(...wrappedNodes);
         return _wrapper;

--- a/src/js/Core/Html/HtmlParser.js
+++ b/src/js/Core/Html/HtmlParser.js
@@ -10,10 +10,6 @@ class HTMLParser {
         return HTML.fragment(html);
     }
 
-    static htmlToElement(html) {
-        return HTML.element(html);
-    }
-
     static getVariableFromText(text, name, type) {
         let regex;
         if (typeof name === "string") {

--- a/src/js/Core/Html/HtmlParser.js
+++ b/src/js/Core/Html/HtmlParser.js
@@ -1,13 +1,8 @@
-import {HTML} from "./Html";
 
 class HTMLParser {
 
     static clearSpecialSymbols(string) {
         return string.replace(/[\u00AE\u00A9\u2122]/g, "");
-    }
-
-    static htmlToDOM(html) {
-        return HTML.fragment(html);
     }
 
     static getVariableFromText(text, name, type) {

--- a/src/js/Core/Html/HtmlParser.js
+++ b/src/js/Core/Html/HtmlParser.js
@@ -1,10 +1,6 @@
 
 class HTMLParser {
 
-    static clearSpecialSymbols(string) {
-        return string.replace(/[\u00AE\u00A9\u2122]/g, "");
-    }
-
     static getVariableFromText(text, name, type) {
         let regex;
         if (typeof name === "string") {

--- a/src/js/Core/Utils/StringUtils.js
+++ b/src/js/Core/Utils/StringUtils.js
@@ -5,6 +5,10 @@ class StringUtils {
     static escapeRegExp(str) {
         return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
     }
+
+    static clearSpecialSymbols(str) {
+        return str.replace(/[\u00AE\u00A9\u2122]/g, "");
+    }
 }
 
 export {StringUtils};

--- a/src/js/Options/Modules/CustomLinks.js
+++ b/src/js/Options/Modules/CustomLinks.js
@@ -10,7 +10,7 @@ class CustomLinks {
     }
 
     init() {
-        this._template = HTML.element(
+        this._template = HTML.toElement(
             `<div class="custom-link option js-custom-link">
                 <input type="checkbox" name="${this._type}_custom_enabled">
                 <div>

--- a/src/js/Options/Modules/Sidebar.js
+++ b/src/js/Options/Modules/Sidebar.js
@@ -143,7 +143,7 @@ class Sidebar {
                 console.warn("Content for sidebar entry not found");
             }
 
-            const groupNode = HTML.element(
+            const groupNode = HTML.toElement(
                 `<div class="sidebar__group js-sb-grp">
                     <a class="sidebar__item sidebar__item--cat${multiClass} js-sb-cat" data-id="${contentId}">
                         ${Localization.getString(localeKey)}


### PR DESCRIPTION
Mainly removed some methods on `HTMLParser` that were just aliases of methods on `HTML`, and renamed them for clarity. (I could never rememeber the capitalization `HTMLParser.htmlToDOM` vs `HTMLParser.getVariableFromDom`, so I chose the latter and deprecated the former.)