### PR TITLE
Make about/footer section on Options translatable

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -349,8 +349,8 @@
 
             <h1 data-locale-text="about">About</h1>
             <div class="section">
-                <p>Augmented Steam is a fork of the Enhanced Steam extension.</p>
-                <p>Visit the <a href="https://augmentedsteam.com/">extension's page</a> or our <a href="https://discord.gg/yn57q7f">Discord channel</a> for more info.</p>
+                <p data-locale-text="options.about_desc">Augmented Steam is a fork of the Enhanced Steam extension.</p>
+                <p class="js-about-text"></p>
             </div>
 
             <h1 data-locale-text="options.maintainers">Project Maintainers</h1>
@@ -407,8 +407,8 @@
 
 <div class="footer">
     <div><a href="https://augmentedsteam.com">Augmented Steam</a></div>
-    <div class="footer__author">a fork by IsThereAnyDeal</div>
-    <div class="footer__author">original author jshackles</div>
+    <div class="footer__author" data-locale-text="options.footer_fork">a fork by IsThereAnyDeal</div>
+    <div class="footer__author" data-locale-text="options.footer_author">original author jshackles</div>
     <div class="footer__buttons">
         <button id="import" data-locale-text="options.settings_mngmt.import">Import</button>
         <button id="export" data-locale-text="options.settings_mngmt.export">Export</button>

--- a/src/js/Content/Modules/AugmentedSteam.js
+++ b/src/js/Content/Modules/AugmentedSteam.js
@@ -8,7 +8,7 @@ import {Background} from "./Background";
 import {DynamicStore} from "./Data/DynamicStore";
 import {User} from "./User";
 import {Page} from "../Features/Page";
-import config from "../../config";
+import Config from "../../config";
 
 class AugmentedSteam {
 
@@ -25,9 +25,9 @@ class AugmentedSteam {
                         <a class="popup_menu_item" target="_blank" href="https://github.com/IsThereAnyDeal/AugmentedSteam">${Localization.str.contribute}</a>
                         <a class="popup_menu_item" target="_blank" href="https://github.com/IsThereAnyDeal/AugmentedSteam/issues">${Localization.str.bug_feature}</a>
                         <div class="hr"></div>
-                        <a class="popup_menu_item" target="_blank" href="${config.PublicHost}">${Localization.str.website}</a>
+                        <a class="popup_menu_item" target="_blank" href="${Config.PublicHost}">${Localization.str.website}</a>
                         <a class="popup_menu_item" target="_blank" href="https://isthereanydeal.com/">IsThereAnyDeal</a>
-                        <a class="popup_menu_item" target="_blank" href="https://discord.gg/yn57q7f">Discord</a>
+                        <a class="popup_menu_item" target="_blank" href="${Config.ITADDiscord}">Discord</a>
                     </div>
                 </div>
             </div>`);

--- a/src/js/Options/Modules/OptionsTranslator.js
+++ b/src/js/Options/Modules/OptionsTranslator.js
@@ -1,5 +1,6 @@
 import {HTML} from "../../Core/Html/Html";
 import {Localization} from "../../Core/Localization/Localization";
+import Config from "../../config";
 
 class OptionsTranslator {
 
@@ -26,13 +27,17 @@ class OptionsTranslator {
     }
 
     static _localizeHtml() {
-        const nodes = document.querySelectorAll("[data-locale-html]");
-        for (const node of nodes) {
-            const translation = this.getTranslation(node.dataset.localeHtml);
-            if (translation) {
-                HTML.inner(node, translation);
-            }
-        }
+        const optionsStr = Localization.str.options;
+
+        // HTML tags are not allowed in localization strings
+        let html = optionsStr.with_help_of
+            .replace("__contributors__", `<a href="https://github.com/IsThereAnyDeal/AugmentedSteam/graphs/contributors">${optionsStr.contributors}</a>`);
+        HTML.inner(".js-contributors-text", html);
+
+        html = optionsStr.about_desc_links.full_text
+            .replace("__linkdescwebsite__", `<a href="${Config.PublicHost}">${optionsStr.about_desc_links.link_text_website}</a>`)
+            .replace("__linkdescdiscord__", `<a href="${Config.ITADDiscord}">${optionsStr.about_desc_links.link_text_discord}</a>`);
+        HTML.inner(".js-about-text", html);
     }
 
     static _localizeLanguageOptions() {
@@ -47,22 +52,11 @@ class OptionsTranslator {
     }
 
     static translate() {
-
         document.title = `Augmented Steam ${Localization.str.thewordoptions}`;
+
         this._localizeText();
         this._localizeHtml();
         this._localizeLanguageOptions();
-
-        // this is not very clean, but I can't figure out better solution right now, having it in-place would be nicer
-        const url = "https://github.com/IsThereAnyDeal/AugmentedSteam/graphs/contributors";
-        HTML.inner(
-            document.querySelector(".js-contributors-text"),
-            Localization.getString("options.with_help_of")
-                .replace(
-                    "__contributors__",
-                    `<a href='${url}'>${Localization.getString("options.contributors")}</a>`
-                )
-        );
     }
 }
 

--- a/src/js/Options/Modules/OptionsTranslator.js
+++ b/src/js/Options/Modules/OptionsTranslator.js
@@ -34,9 +34,9 @@ class OptionsTranslator {
             .replace("__contributors__", `<a href="https://github.com/IsThereAnyDeal/AugmentedSteam/graphs/contributors">${optionsStr.contributors}</a>`);
         HTML.inner(".js-contributors-text", html);
 
-        html = optionsStr.about_desc_links.full_text
-            .replace("__linkdescwebsite__", `<a href="${Config.PublicHost}">${optionsStr.about_desc_links.link_text_website}</a>`)
-            .replace("__linkdescdiscord__", `<a href="${Config.ITADDiscord}">${optionsStr.about_desc_links.link_text_discord}</a>`);
+        html = optionsStr.about_desc_links
+            .replace("__website__", `<a href="${Config.PublicHost}">${Localization.str.website.toLowerCase()}</a>`)
+            .replace("__discord__", `<a href="${Config.ITADDiscord}">Discord</a>`);
         HTML.inner(".js-about-text", html);
     }
 

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -4,5 +4,6 @@ export default {
     "ApiServerHost": "https://esapi.isthereanydeal.com",
     "PublicHost": "https://augmentedsteam.com",
     "ITADApiServerHost": "https://api.isthereanydeal.com",
-    "ITADClientId": "5fe78af07889f43a"
+    "ITADClientId": "5fe78af07889f43a",
+    "ITADDiscord": "https://discord.gg/yn57q7f",
 };

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -668,11 +668,7 @@
         "with_help_of": "with a lot of help by our __contributors__",
         "contributors": "wonderful contributors",
         "about_desc": "Augmented Steam is a fork of the Enhanced Steam extension.",
-        "about_desc_links": {
-            "link_text_website": "extension's website",
-            "link_text_discord": "Discord channel",
-            "full_text": "Visit the __linkdescwebsite__ or our __linkdescdiscord__ for more info."
-        },
+        "about_desc_links": "Visit the extension's __website__ or our __discord__ for more info.",
         "footer_fork": "a fork by IsThereAnyDeal",
         "footer_author": "original author jshackles"
     },

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -666,7 +666,15 @@
         "add_to_waitlist": "Show \"Add to Waitlist\" dropdown on app pages",
         "maintainers": "Project Maintainers",
         "with_help_of": "with a lot of help by our __contributors__",
-        "contributors": "wonderful contributors"
+        "contributors": "wonderful contributors",
+        "about_desc": "Augmented Steam is a fork of the Enhanced Steam extension.",
+        "about_desc_links": {
+            "link_text_website": "extension's website",
+            "link_text_discord": "Discord channel",
+            "full_text": "Visit the __linkdescwebsite__ or our __linkdescdiscord__ for more info."
+        },
+        "footer_fork": "a fork by IsThereAnyDeal",
+        "footer_author": "original author jshackles"
     },
     "ready": {
         "errormsg": "Error loading Augmented Steam data",


### PR DESCRIPTION
Replaced the `OptionsTranslator._localizeHtml` method now that HTML tags are not allowed in localization strings.

Also added our Discord to the config file. We may want an entry for the ITAD site as well (https://isthereanydeal.com/) to support using the new site once it's ready?