### PR TITLE
Remove newline char in localization string

### DIFF
--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -329,7 +329,7 @@
     "separator": "Separator",
     "empty_wishlist": {
         "title": "Empty wishlist",
-        "confirm": "Are you sure you want to empty your wishlist?\n\nThis action cannot be undone!",
+        "confirm": "Are you sure you want to empty your wishlist? This action cannot be undone!",
         "removing": "Removing app __cur__ from __total__..."
     },
     "about": "About",


### PR DESCRIPTION
We don't have CSS to handle these and it doesn't seem necessary.