### PR TITLE
Disable button after showing hidden achievements

### DIFF
--- a/src/js/Content/Features/Community/Stats/FShowHiddenAchievements.js
+++ b/src/js/Content/Features/Community/Stats/FShowHiddenAchievements.js
@@ -63,7 +63,7 @@ export default class FShowHiddenAchievements extends Feature {
                     </div>`);
             }
 
-            parent.remove();
+            btn.classList.add("btn_disabled");
         });
     }
 }


### PR DESCRIPTION
Fixes https://github.com/IsThereAnyDeal/AugmentedSteam/commit/e72b62fc0096ecbc75e6dea055d0765280d7f8bb#commitcomment-88901300, in case it gets forgotton...

IMO it's easier to leave the row intact for now.