### PR TITLE
Completely darken alternative linux icon on tab focus

### DIFF
--- a/src/js/Content/Features/Store/Common/FAlternativeLinuxIcon.js
+++ b/src/js/Content/Features/Store/Common/FAlternativeLinuxIcon.js
@@ -13,7 +13,7 @@ export default class FAlternativeLinuxIcon extends Feature {
         let cssText = `span.platform_img.linux { background-image: url(${url}) !important; }`;
 
         if (this.context.type === ContextType.STORE_FRONT) {
-            cssText += ".tab_item.focus .tab_item_details span.platform_img.linux { filter: brightness(20%); }";
+            cssText += ".tab_item.focus .tab_item_details span.platform_img.linux { filter: brightness(0%); }";
         }
 
         DOMHelper.insertCSS(cssText);


### PR DESCRIPTION
Improves icon visibility when the tab is highlighed and focused at the same time.

Before:
![螢幕擷取畫面 2022-12-12 001403](https://user-images.githubusercontent.com/54083835/208398824-4be8124d-d98e-4943-a788-c0dfc5b964b5.jpg)
