### PR TITLE
Improve store country detection on market-related pages

### DIFF
--- a/src/js/Content/Modules/User.js
+++ b/src/js/Content/Modules/User.js
@@ -68,6 +68,9 @@ class User {
                     const config = document.querySelector("#webui_config, #application_config");
                     if (config) {
                         newCountry = JSON.parse(config.dataset.config).COUNTRY;
+                    } else {
+                        // This variable is present on market-related pages
+                        newCountry = HTMLParser.getVariableFromDom("g_strCountryCode", "string");
                     }
                 }
 


### PR DESCRIPTION
An alternative is to find the `g_rgWalletInfo` object, which has a `wallet_country` key. Not sure if it's always present and equal to store country though.