### PR TITLE
Avoid trimming game name in launch random app modal title

### DIFF
--- a/src/js/Content/Modules/AugmentedSteam.js
+++ b/src/js/Content/Modules/AugmentedSteam.js
@@ -236,7 +236,7 @@ class AugmentedSteam {
                     });
                 },
                 [
-                    Localization.str.play_game.replace("__gamename__", gamename.replace("'", "").trim()),
+                    Localization.str.play_game.replace("__gamename__", gamename),
                     gameid,
                     Localization.str.visit_store,
                 ]);

--- a/src/js/Content/Modules/AugmentedSteam.js
+++ b/src/js/Content/Modules/AugmentedSteam.js
@@ -200,8 +200,7 @@ class AugmentedSteam {
 
         HTML.beforeEnd(
             "#es_popup .popup_menu",
-            `<div class="hr"></div>
-             <a id="es_random_game" class="popup_menu_item" style="cursor: pointer;">${Localization.str.launch_random}</a>`
+            `<div class="hr"></div><a id="es_random_game" class="popup_menu_item">${Localization.str.launch_random}</a>`
         );
 
         document.querySelector("#es_random_game").addEventListener("click", async() => {
@@ -212,22 +211,16 @@ class AugmentedSteam {
                 if (!response || !response.success) { return; }
                 const data = response.data;
 
-                let gameid = appid;
-                let gamename;
-                if (data.fullgame) {
-                    gameid = data.fullgame.appid;
-                    gamename = data.fullgame.name;
-                } else {
-                    gamename = data.name;
-                }
+                const gameid = data.fullgame?.appid ?? appid;
+                const gamename = data.fullgame?.name ?? data.name;
 
-                Page.runInPageContext((playGameStr, gameid, visitStore) => {
+                Page.runInPageContext((playGameStr, gameid, visitStoreStr) => {
                     const prompt = window.SteamFacade.showConfirmDialog(
                         playGameStr,
                         `<img src="//cdn.cloudflare.steamstatic.com/steam/apps/${gameid}/header.jpg">`,
                         null,
                         null,
-                        visitStore
+                        visitStoreStr
                     );
 
                     prompt.done(result => {


### PR DESCRIPTION
This is leftover from ES where the script passed to `runInPageContext()` was formed by string concatenation.