### PR TITLE
Fix tab image placement after clicking tabs on workshop home 

### DIFF
--- a/src/js/Content/Features/Community/Workshop/FBrowseWorkshops.js
+++ b/src/js/Content/Features/Community/Workshop/FBrowseWorkshops.js
@@ -8,13 +8,15 @@ export default class FBrowseWorkshops extends Feature {
 
         let url = new URL(window.location.href);
 
-        if (url.searchParams && url.searchParams.has("browsesort")) {
+        if (url.searchParams.has("browsesort")) {
             LocalStorage.set("workshop_state", url.search);
         } else {
             const search = LocalStorage.get("workshop_state");
-            url = new URL(`https://steamcommunity.com/workshop/${search}`);
-            const query = url.searchParams.get("browsesort");
-            this._changeTab(query);
+            if (search) {
+                url = new URL(search, "https://steamcommunity.com/workshop/");
+                const query = url.searchParams.get("browsesort");
+                this._changeTab(query);
+            }
         }
 
         Page.runInPageContext(() => {

--- a/src/js/Content/Features/Community/Workshop/FBrowseWorkshops.js
+++ b/src/js/Content/Features/Community/Workshop/FBrowseWorkshops.js
@@ -6,6 +6,26 @@ export default class FBrowseWorkshops extends Feature {
 
     apply() {
 
+        for (const tab of document.querySelectorAll(".browseOption")) {
+            const a = tab.querySelector("a");
+            const href = a.href;
+            a.removeAttribute("href");
+
+            if (tab.classList.contains("notSelected")) {
+                HTML.wrap('<div style="position: relative;"></div>', tab);
+            }
+
+            const newTab = HTML.replace(tab, tab.outerHTML); // Sanitize click listeners
+
+            newTab.addEventListener("click", () => {
+                const url = new URL(href, "https://steamcommunity.com/workshop/");
+                const query = url.searchParams.get("browsesort");
+                LocalStorage.set("workshop_state", url.search);
+                window.history.pushState(null, null, url.search);
+                this._changeTab(query);
+            });
+        }
+
         let url = new URL(window.location.href);
 
         if (url.searchParams.has("browsesort")) {
@@ -18,23 +38,6 @@ export default class FBrowseWorkshops extends Feature {
                 this._changeTab(query);
             }
         }
-
-        Page.runInPageContext(() => {
-            window.SteamFacade.jq(".browseOption")
-                .get()
-                .forEach(node => { node.onclick = () => false; });
-        });
-
-        document.querySelectorAll(".browseOption").forEach(tab => {
-            tab.addEventListener("click", () => {
-                const a = tab.querySelector("a[href]");
-                const url = new URL(`https://steamcommunity.com/workshop/${a.href}`);
-                const query = url.searchParams.get("browsesort");
-                LocalStorage.set("workshop_state", url.search);
-                window.history.pushState(null, null, url.search);
-                this._changeTab(query);
-            });
-        });
     }
 
     async _changeTab(query, start = 0, count = 8) {
@@ -43,8 +46,7 @@ export default class FBrowseWorkshops extends Feature {
 
         tab.setAttribute("disabled", "disabled");
 
-        const image = document.querySelector(".browseOptionImage");
-        tab.parentNode.insertAdjacentElement("afterbegin", image);
+        tab.before(document.querySelector(".browseOptionImage"));
 
         document.querySelectorAll(".browseOption").forEach(tab => tab.classList.add("notSelected"));
         tab.classList.remove("notSelected");

--- a/src/js/Core/Html/Html.js
+++ b/src/js/Core/Html/Html.js
@@ -63,10 +63,13 @@ class HTML {
     static replace(node, html) {
         const _node = HTML._getNode(node);
 
-        if (_node) {
-            _node.outerHTML = DOMPurify.sanitize(html);
-        }
-        return _node;
+        if (!_node) { return null; }
+
+        const dom = HTML.toDom(html); // Support replacing with multiple nodes
+        const firstEl = dom.firstElementChild; // Save reference before emptying the docFrag
+        _node.replaceWith(dom);
+
+        return firstEl;
     }
 
     static wrap(wrapper, startEl, endEl = startEl) {


### PR DESCRIPTION
Also fixed a possible error if the `workshop_state` value is an empty string (initial value).

Note: I couldn't figure out why removing the `onclick` attribute doesn't remove the click listener, so I ran it through the sanitizer. Also changed the `HTML.replace` method to return the first element of the replaced nodes, since it doesn't make sense to return the original node.