### PR TITLE
Add feature to remove duplicate screenshots on store pages

### DIFF
--- a/src/js/Content/Features/Store/App/CApp.js
+++ b/src/js/Content/Features/Store/App/CApp.js
@@ -45,6 +45,7 @@ import FSaveReviewFilters from "./FSaveReviewFilters";
 import FHideReportedTags from "./FHideReportedTags";
 import FPatchHighlightPlayer from "./FPatchHighlightPlayer";
 import FSteamDeckCompatibility from "./FSteamDeckCompatibility";
+import FRemoveDupeScreenshots from "./FRemoveDupeScreenshots";
 
 export class CApp extends CStoreBase {
 
@@ -104,6 +105,7 @@ export class CApp extends CStoreBase {
             FAddToCartNoRedirect,
             FPatchHighlightPlayer,
             FSteamDeckCompatibility,
+            FRemoveDupeScreenshots,
         ]);
 
         this.appid = GameId.getAppid(window.location.host + window.location.pathname);

--- a/src/js/Content/Features/Store/App/FRemoveDupeScreenshots.js
+++ b/src/js/Content/Features/Store/App/FRemoveDupeScreenshots.js
@@ -1,0 +1,26 @@
+import {Feature} from "../../../modulesContent";
+
+export default class FRemoveDupeScreenshots extends Feature {
+
+    checkPrerequisites() {
+        this._screenshots = document.querySelectorAll(".highlight_screenshot");
+        return this._screenshots.length > 1;
+    }
+
+    apply() {
+
+        // Remove duplicate screenshots otherwise the highlight player will always scroll to the first one
+        const ids = new Set();
+
+        for (const node of this._screenshots) {
+            const id = CSS.escape(node.id); // ends with file extension
+
+            if (ids.has(id)) {
+                node.remove();
+                document.querySelectorAll(`#${id.replace("highlight_", "thumb_")}`)[1].remove();
+            } else {
+                ids.add(id);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Removes duplicate screenshots (specifically those with duplicate `id`s) otherwise the highlight player will keep scrolling back to the first one. Someone mentioned this on Discord before but back then I didn't know how to code 😄.

Store page for testing: `https://store.steampowered.com/app/1201270/__A_Space_for_the_Unbound/`
(They might fix it at some point)