### PR TITLE
CSS: Fix badge row text display

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -49,6 +49,18 @@
 .achieveTxt h3.ellipsis {
   white-space: normal;
 }
+/**
+ * https://github.com/IsThereAnyDeal/AugmentedSteam/pull/1590
+ * Fix badge row text display
+ */
+.badge_content > .badge_current {
+    float: initial;
+    width: initial;
+}
+.badge_content > .badge_progress_info + .badge_current {
+    width: 296px;
+    float: left;
+}
 
 /* Back To Top button */
 .es_btt {


### PR DESCRIPTION
This aims to fix unnecessary line breaks within badge rows due to the width being too small.

Before:
![badges_bug](https://user-images.githubusercontent.com/54083835/221177475-502c65c7-12c7-484a-b0a2-c64c1a5cfd5e.jpg)

Fixed:
![badges_fixed](https://user-images.githubusercontent.com/54083835/221177505-62e49e05-e966-454a-8387-bca445b3f9c6.jpg)

The issue might be more frequent on other locales. I've tested this on game cards and badges home, and ensured it doesn't break the text display of in-progess badges.