### PR TITLE
Change the color of quick sell buttons

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -800,17 +800,12 @@ img.astats_icon {
  * User Inventory
  * FQuickSellOptions
  **************************************/
-/**
- * We need higher precedence to override the display property of .item_market_action_button
- * https://github.com/SteamDatabase/SteamTracking/blob/9868c2d72e43193c6db4530a9b3842af63563fd7/steamcommunity.com/public/css/skin_1/economy.css#L944
- */
-.item_market_actions .item_market_action_button {
+.es_qsell_ctn .btn_small {
   margin-bottom: 4px;
   overflow: hidden;
   width: max-content;
-  display: block;
 }
-.item_market_actions .item_market_action_button[id^=es_],
+.es_qsell_ctn .btn_small,
 .es_qsell_loading {
   display: none;
 }

--- a/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
+++ b/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
@@ -38,23 +38,20 @@ export default class FQuickSellOptions extends CallbackFeature {
 
         // marketActions' innerHTML is cleared on item selection, so the links HTML has to be re-inserted
         HTML.beforeEnd(marketActions,
-            `<a class="item_market_action_button item_market_action_button_green" id="es_quicksell${view}" data-tooltip-text="${Localization.str.quick_sell_desc.replace("__modifier__", diff)}">
-                <span class="item_market_action_button_edge item_market_action_button_left"></span>
-                <span class="item_market_action_button_contents"></span>
-                <span class="item_market_action_button_edge item_market_action_button_right"></span>
-                <span class="item_market_action_button_preload"></span>
-            </a>
-            <a class="item_market_action_button item_market_action_button_green" id="es_instantsell${view}" data-tooltip-text="${Localization.str.instant_sell_desc}">
-                <span class="item_market_action_button_edge item_market_action_button_left"></span>
-                <span class="item_market_action_button_contents"></span>
-                <span class="item_market_action_button_edge item_market_action_button_right"></span>
-                <span class="item_market_action_button_preload"></span>
-            </a>
-            <div class="es_loading es_qsell_loading">
-                <img src="//community.cloudflare.steamstatic.com/public/images/login/throbber.gif">
-                <span>${Localization.str.selling}</span>
+            `<div class="es_qsell_ctn">
+                <a class="btn_small btn_grey_white_innerfade" id="es_quicksell${view}" data-tooltip-text="${Localization.str.quick_sell_desc.replace("__modifier__", diff)}">
+                    <span></span>
+                </a>
+                <a class="btn_small btn_grey_white_innerfade" id="es_instantsell${view}" data-tooltip-text="${Localization.str.instant_sell_desc}">
+                    <span></span>
+                </a>
+                <div class="es_loading es_qsell_loading">
+                    <img src="//community.cloudflare.steamstatic.com/public/images/login/throbber.gif">
+                    <span>${Localization.str.selling}</span>
+                </div>
             </div>`);
 
+        // Steam's mutation observer for tooltips is disabled on inventories, so add them manually
         Page.runInPageContext(view => {
             window.SteamFacade.vTooltip(`#es_quicksell${view}, #es_instantsell${view}`);
         }, [view]);
@@ -92,7 +89,7 @@ export default class FQuickSellOptions extends CallbackFeature {
         const currencyType = CurrencyManager.currencyNumberToType(walletCurrency);
 
         function enableButtons(enable) {
-            for (const button of marketActions.querySelectorAll(".item_market_action_button")) {
+            for (const button of marketActions.querySelectorAll(".item_market_action_button, .btn_small")) {
                 button.classList.toggle("btn_disabled", !enable);
             }
         }
@@ -182,7 +179,7 @@ export default class FQuickSellOptions extends CallbackFeature {
             (price, type) => window.SteamFacade.vCurrencyFormat(price, type), [priceVal, currencyType], true
         );
 
-        buttonEl.querySelector(".item_market_action_button_contents").textContent = buttonStr.replace("__amount__", formattedPrice);
+        buttonEl.querySelector("span").textContent = buttonStr.replace("__amount__", formattedPrice);
         buttonEl.dataset.price = priceVal;
         buttonEl.style.display = "block";
         buttonEl.addEventListener("click", clickHandler);


### PR DESCRIPTION
This changes the color of quick sell buttons to grey so the white text is easier to read. Also avoids CSS tricks to override the display property. Another option is to use blue, like SteamDB does.

![2023-04-04_173000](https://user-images.githubusercontent.com/54083835/233939198-9ff4c42e-7077-472e-8358-8711e22f3458.jpg)