### PR TITLE
FMarketLowestPrice: Alert the user and avoid sending requests once timed-out, increase delay

### DIFF
--- a/src/js/Content/Features/Community/MarketHome/FMarketLowestPrice.js
+++ b/src/js/Content/Features/Community/MarketHome/FMarketLowestPrice.js
@@ -7,7 +7,7 @@ export default class FMarketLowestPrice extends CallbackFeature {
         super(context);
 
         this._loadedMarketPrices = {};
-        this._delayMs = 1000; // Delay to put between requests in attempt to avoid 429s
+        this._delayMs = 2000; // Delay to put between requests in attempt to avoid 429s
         this._delay = false; // Whether to put a delay between requests
         this._timeout = false; // Whether the user has been timed-out
     }

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -23,6 +23,7 @@
     "thewordno": "No",
     "theworderror": "Error",
     "no_data": "No data",
+    "toomanyrequests": "Too Many Requests",
     "show_comments": "Show Comments",
     "hide_comments": "Hide Comments",
     "calc_workshop_size": {


### PR DESCRIPTION
I no longer think it makes sense to retry after 429s. From my experience, it lasts for at least 1 hour and resets every time you access the endpoint. 30 seconds is too long anyway and users will simply think the page has stalled, so change it to alert the user immediately and avoid sending more requests.

Also increased the delay between requests to 2 seconds as discussed in https://github.com/IsThereAnyDeal/AugmentedSteam/issues/1594#issuecomment-1453807286.

Closes #1594.