### PR TITLE
Wishlist: fix page hang caused by asynchronously adding notes

### DIFF
--- a/src/js/Content/Features/Store/Wishlist/FWishlistUserNotes.js
+++ b/src/js/Content/Features/Store/Wishlist/FWishlistUserNotes.js
@@ -29,12 +29,13 @@ export default class FWishlistUserNotes extends CallbackFeature {
 
     callback(nodes) {
 
-        const lastNode = nodes[nodes.length - 1];
-
         for (const node of nodes) {
             if (node.classList.contains("esi-has-note")) { continue; }
 
             const noteEl = this._noteEl.cloneNode(true);
+            node.querySelector(".mid_container").after(noteEl);
+            node.classList.add("esi-has-note");
+
             const appid = Number(node.dataset.appId);
 
             (async() => {
@@ -43,13 +44,6 @@ export default class FWishlistUserNotes extends CallbackFeature {
                 if (note !== null) {
                     noteEl.textContent = `"${note}"`;
                     noteEl.classList.add("esi-has-note");
-                }
-
-                node.querySelector(".mid_container").insertAdjacentElement("afterend", noteEl);
-                node.classList.add("esi-has-note");
-
-                if (node === lastNode) {
-                    window.dispatchEvent(new Event("resize"));
                 }
             })();
         }


### PR DESCRIPTION
Fixes #1608.
Fixes #1115.

I was able to reproduce the tab hang by opening own wishlist with "User Notes > On Wishlist" enabled, then once the wishlist finish loading immediately move the scrollbar around.

#1608 was filed right after v2.0.1 released, which included https://github.com/IsThereAnyDeal/AugmentedSteam/commit/e84b99182b3c9285bb77963fca130aebd12477b7 that changed to adding the notes container asynchronously. Adding notes changes row height, which causes the rows to overlap, which we then fix by dispatching a `resize` event so Steam runs `CWishlistController.OnResize`. But adding it asynchronously may cause some weird issue where Steam is unable to record changes to the row height correctly, resulting in an infinite loop that hangs the tab. Heap profile example: [heapprofile.zip](https://github.com/IsThereAnyDeal/AugmentedSteam/files/11399956/heapprofile.zip).

The fix is to add the notes container synchronously then update the contents if needed.