### PR TITLE
Refactor and fixup reviews sort

### DIFF
--- a/src/js/Background/Modules/SteamCommunityApi.js
+++ b/src/js/Background/Modules/SteamCommunityApi.js
@@ -221,7 +221,7 @@ class SteamCommunityApi extends Api {
             return Number(input.id.replace("ReviewVisibility", ""));
         }
 
-        // Otherwise you have buttons to vote for the review
+        // Otherwise you have buttons to vote for and award the review
         return Number(node.querySelector(".control_block > a").id.replace("RecommendationVoteUpBtn", ""));
     }
 

--- a/src/js/Background/Modules/SteamCommunityApi.js
+++ b/src/js/Background/Modules/SteamCommunityApi.js
@@ -239,6 +239,9 @@ class SteamCommunityApi extends Api {
 
                 const playtimeText = node.querySelector(".hours").textContent.split("(")[0].match(/(\d+,)?\d+\.\d+/);
                 const visibilityNode = node.querySelector(".dselect_container:nth-child(2) .trigger");
+                const devResponseNode = node.nextElementSibling.classList.contains("review_developer_response_container")
+                    ? DOMPurify.sanitize(node.nextElementSibling.outerHTML)
+                    : "";
 
                 const id = SteamCommunityApi._getReviewId(node);
                 const rating = node.querySelector("[src*=thumbsUp]") ? 1 : 0;
@@ -260,7 +263,7 @@ class SteamCommunityApi extends Api {
                     length,
                     visibility,
                     playtime,
-                    "node": DOMPurify.sanitize(node.outerHTML),
+                    "node": DOMPurify.sanitize(node.outerHTML) + devResponseNode,
                     id
                 });
             }

--- a/src/js/Background/Modules/SteamCommunityApi.js
+++ b/src/js/Background/Modules/SteamCommunityApi.js
@@ -270,7 +270,7 @@ class SteamCommunityApi extends Api {
 
         if (!await IndexedDB.contains("reviews", steamId, {"preventFetch": true})) { return null; }
 
-        const reviews = await IndexedDB.get("reviews", steamId, {"params": reviewCount});
+        const reviews = await SteamCommunityApi.getReviews(steamId, reviewCount);
 
         for (const review of reviews) {
             if (review.id === id) {

--- a/src/js/Background/Modules/SteamCommunityApi.js
+++ b/src/js/Background/Modules/SteamCommunityApi.js
@@ -229,11 +229,14 @@ class SteamCommunityApi extends Api {
         const parser = new DOMParser();
         const pageCount = 10;
         const reviews = [];
+        let defaultOrder = 0;
 
         for (let p = 1; p <= Math.ceil(reviewCount / pageCount); p++) {
             const doc = parser.parseFromString(await SteamCommunityApi.getPage(`${steamId}/recommended`, {p}), "text/html");
 
             for (const node of doc.querySelectorAll(".review_box")) {
+                defaultOrder++;
+
                 const headerText = node.querySelector(".header").innerHTML.split("<br>");
                 const playtimeText = node.querySelector(".hours").textContent.split("(")[0].match(/(\d+,)?\d+\.\d+/);
                 const visibilityNode = node.querySelector(".dselect_container:nth-child(2) .trigger");
@@ -247,6 +250,7 @@ class SteamCommunityApi extends Api {
                 const playtime = playtimeText ? parseFloat(playtimeText[0].split(",").join("")) : 0.0;
 
                 reviews.push({
+                    "default": defaultOrder,
                     rating,
                     helpful,
                     funny,

--- a/src/js/Background/Modules/SteamCommunityApi.js
+++ b/src/js/Background/Modules/SteamCommunityApi.js
@@ -216,15 +216,12 @@ class SteamCommunityApi extends Api {
     static _getReviewId(node) {
         const input = node.querySelector("input");
 
-        /*
-         * Only exists when the requested profile is yours
-         * (these are the input fields where you can change visibility and language of the review)
-         */
+        // Only exists when the requested profile is yours
         if (input) {
             return Number(input.id.replace("ReviewVisibility", ""));
         }
 
-        // Otherwise you have buttons to vote for the review (Was it helpful or not, was it funny?)
+        // Otherwise you have buttons to vote for the review
         return Number(node.querySelector(".control_block > a").id.replace("RecommendationVoteUpBtn", ""));
     }
 

--- a/src/js/Background/Modules/SteamCommunityApi.js
+++ b/src/js/Background/Modules/SteamCommunityApi.js
@@ -237,7 +237,7 @@ class SteamCommunityApi extends Api {
             for (const node of doc.querySelectorAll(".review_box")) {
                 defaultOrder++;
 
-                const playtimeText = node.querySelector(".hours").textContent.split("(")[0].match(/(\d+,)?\d+\.\d+/);
+                const playtimeText = node.querySelector(".hours").textContent.match(/(?:\d+,)?\d+\.\d+/);
                 const visibilityNode = node.querySelector("input[id^=ReviewVisibility]");
                 const devResponseNode = node.nextElementSibling.classList.contains("review_developer_response_container")
                     ? DOMPurify.sanitize(node.nextElementSibling.outerHTML)
@@ -253,7 +253,7 @@ class SteamCommunityApi extends Api {
                     });
                 const length = node.querySelector(".content").textContent.trim().length;
                 const visibility = visibilityNode ? Number(visibilityNode.value) : 0; // Public: 0; Friends-only: 1
-                const playtime = playtimeText ? parseFloat(playtimeText[0].split(",").join("")) : 0.0;
+                const playtime = playtimeText ? parseFloat(playtimeText[0].replace(/,/g, "")) : 0.0;
 
                 reviews.push({
                     "default": defaultOrder,

--- a/src/js/Background/Modules/SteamCommunityApi.js
+++ b/src/js/Background/Modules/SteamCommunityApi.js
@@ -238,7 +238,7 @@ class SteamCommunityApi extends Api {
                 defaultOrder++;
 
                 const playtimeText = node.querySelector(".hours").textContent.split("(")[0].match(/(\d+,)?\d+\.\d+/);
-                const visibilityNode = node.querySelector(".dselect_container:nth-child(2) .trigger");
+                const visibilityNode = node.querySelector("input[id^=ReviewVisibility]");
                 const devResponseNode = node.nextElementSibling.classList.contains("review_developer_response_container")
                     ? DOMPurify.sanitize(node.nextElementSibling.outerHTML)
                     : "";
@@ -252,7 +252,7 @@ class SteamCommunityApi extends Api {
                         return text ? Number(text[0].replace(/,/g, "")) : 0;
                     });
                 const length = node.querySelector(".content").textContent.trim().length;
-                const visibility = visibilityNode ? visibilityNode.textContent : "Public";
+                const visibility = visibilityNode ? Number(visibilityNode.value) : 0; // Public: 0; Friends-only: 1
                 const playtime = playtimeText ? parseFloat(playtimeText[0].split(",").join("")) : 0.0;
 
                 reviews.push({

--- a/src/js/Background/Modules/SteamCommunityApi.js
+++ b/src/js/Background/Modules/SteamCommunityApi.js
@@ -237,14 +237,17 @@ class SteamCommunityApi extends Api {
             for (const node of doc.querySelectorAll(".review_box")) {
                 defaultOrder++;
 
-                const headerText = node.querySelector(".header").innerHTML.split("<br>");
                 const playtimeText = node.querySelector(".hours").textContent.split("(")[0].match(/(\d+,)?\d+\.\d+/);
                 const visibilityNode = node.querySelector(".dselect_container:nth-child(2) .trigger");
 
                 const id = SteamCommunityApi._getReviewId(node);
                 const rating = node.querySelector("[src*=thumbsUp]") ? 1 : 0;
-                const helpful = headerText[0] && headerText[0].match(/\d+/g) ? parseInt(headerText[0].match(/\d+/g).join("")) : 0;
-                const funny = headerText[1] && headerText[1].match(/\d+/g) ? parseInt(headerText[1].match(/\d+/g).join("")) : 0;
+                const [helpful = 0, funny = 0] = Array.from(node.querySelector(".header").childNodes)
+                    .filter(node => node.nodeType === 3)
+                    .map(node => {
+                        const text = node.textContent.match(/(?:\d+,)?\d+/);
+                        return text ? Number(text[0].replace(/,/g, "")) : 0;
+                    });
                 const length = node.querySelector(".content").textContent.trim().length;
                 const visibility = visibilityNode ? visibilityNode.textContent : "Public";
                 const playtime = playtimeText ? parseFloat(playtimeText[0].split(",").join("")) : 0.0;

--- a/src/js/Background/Modules/SteamCommunityApi.js
+++ b/src/js/Background/Modules/SteamCommunityApi.js
@@ -255,6 +255,13 @@ class SteamCommunityApi extends Api {
                 const visibility = visibilityNode ? Number(visibilityNode.value) : 0; // Public: 0; Friends-only: 1
                 const playtime = playtimeText ? parseFloat(playtimeText[0].replace(/,/g, "")) : 0.0;
 
+                // Count total awards received
+                const awards = Array.from(node.querySelectorAll(".review_award"))
+                    .reduce((acc, node) => {
+                        const count = node.classList.contains("more_btn") ? 0 : Number(node.querySelector(".review_award_count").textContent.trim());
+                        return acc + count;
+                    }, 0);
+
                 reviews.push({
                     "default": defaultOrder,
                     rating,
@@ -263,6 +270,7 @@ class SteamCommunityApi extends Api {
                     length,
                     visibility,
                     playtime,
+                    awards,
                     "node": DOMPurify.sanitize(node.outerHTML) + devResponseNode,
                     id
                 });

--- a/src/js/Content/Features/Community/Recommended/FReviewSort.js
+++ b/src/js/Content/Features/Community/Recommended/FReviewSort.js
@@ -4,150 +4,22 @@ import {Page} from "../../Page";
 
 export default class FReviewSort extends Feature {
 
+    checkPrerequisites() {
+        return document.querySelectorAll(".review_box").length > 1;
+    }
+
     apply() {
 
-        const numReviewsNode = document.querySelector(".review_stat:nth-child(1) .giantNumber");
-        if (!numReviewsNode) { return; }
+        const pagingInfo = document.querySelector(".workshopBrowsePagingInfo").textContent;
+        this._numReviews = Math.max(...pagingInfo.replace(/,/g, "").match(/\d+/g));
+        this._path = window.location.pathname.match(/\/((?:id|profiles)\/.+?)\//)[1];
 
-        const numReviews = Number(numReviewsNode.innerText);
-        if (isNaN(numReviews) || numReviews <= 1) { return; }
-
-        const steamId = window.location.pathname.match(/\/((?:id|profiles)\/.+?)\//)[1];
-        const params = new URLSearchParams(window.location.search);
-        const curPage = params.get("p") || 1;
-        const pageCount = 10;
-        let reviews;
-
-        async function getReviews() {
-
-            // Delay half a second to avoid dialog flicker when grabbing cache
-            await TimeUtils.timer(500);
-
-            Page.runInPageContext((processing, wait) => {
-                window.SteamFacade.showBlockingWaitDialog(processing, wait);
-            }, [Localization.str.processing, Localization.str.wait]);
-
-            try {
-                reviews = await Background.action("reviews", steamId, numReviews);
-
-                reviews.map((review, i) => {
-                    review.default = i;
-                    return review;
-                });
-            } finally {
-                Page.runInPageContext(() => {
-                    window.SteamFacade.dismissActiveModal();
-                });
-            }
-        }
-
-        async function sortReviews(sortBy, reverse) {
-            if (!reviews) {
-                await getReviews();
-            }
-
-            for (const node of document.querySelectorAll(".review_box")) {
-                node.remove();
-            }
-
-            let displayedReviews = reviews.sort((a, b) => {
-                switch (sortBy) {
-                    case "rating":
-                    case "helpful":
-                    case "funny":
-                    case "length":
-                    case "playtime":
-                        return b[sortBy] - a[sortBy];
-                    case "visibility": {
-                        const _a = a[sortBy].toLowerCase();
-                        const _b = b[sortBy].toLowerCase();
-                        if (_a > _b) { return -1; }
-                        if (_a < _b) { return 1; }
-                        return 0;
-                    }
-                    case "default":
-                        return a[sortBy] - b[sortBy];
-                    default:
-                        // eslint-disable-next-line no-invalid-this -- this is binded to an instance of FReviewSort
-                        this.logError(
-                            new Error("Invalid sorting criteria"),
-                            "Can't sort reviews by criteria '%s'",
-                            sortBy,
-                        );
-                        return 0;
-                }
-            });
-
-            if (reverse) {
-                displayedReviews.reverse();
-            }
-
-            displayedReviews = displayedReviews.slice(pageCount * (curPage - 1), pageCount * curPage);
-
-            const footer = document.querySelector("#leftContents > .workshopBrowsePaging:last-child");
-            for (const {node} of displayedReviews) {
-                HTML.beforeBegin(footer, node);
-            }
-
-            // Add back sanitized event handlers
-            Page.runInPageContext(ids => {
-                Array.from(document.querySelectorAll(".review_box")).forEach((node, boxIndex) => {
-                    const id = ids[boxIndex];
-
-                    const containers = node.querySelectorAll(".dselect_container");
-
-                    /*
-                     * Only exists when the requested profile is yours (these are the input
-                     * fields where you can change visibility and language of the review)
-                     */
-                    if (containers.length) {
-                        for (const container of node.querySelectorAll(".dselect_container")) {
-                            const type = container.id.startsWith("ReviewVisibility") ? "Visibility" : "Language";
-                            const input = container.querySelector("input");
-                            const trigger = container.querySelector(".trigger");
-                            const selections = Array.from(container.querySelectorAll(".dropcontainer a"));
-
-                            input.onchange = () => { window[`OnReview${type}Change`](id, `Review${type}${id}`); };
-
-                            /* eslint-disable no-script-url, no-undef, new-cap, no-loop-func --
-                             * The D* functions are not actual references in this context,
-                             * they're functions in the page context. */
-                            trigger.href = "javascript:DSelectNoop();";
-                            trigger.onfocus = () => DSelectOnFocus(`Review${type}${id}`);
-                            trigger.onblur = () => DSelectOnBlur(`Review${type}${id}`);
-                            trigger.onclick = () => DSelectOnTriggerClick(`Review${type}${id}`);
-
-                            selections.forEach((selection, selIndex) => {
-                                selection.href = "javascript:DSelectNoop();";
-                                selection.onmouseover = () => DHighlightItem(`Review${type}${id}`, selIndex, false);
-                                selection.onclick = () => DHighlightItem(`Review${type}${id}`, selIndex, true);
-                            });
-                            /* eslint-enable no-script-url, no-undef, new-cap, no-loop-func */
-                        }
-
-                    // Otherwise you have buttons to vote for the review (Was it helpful or not, was it funny?)
-                    } else {
-                        const controlBlock = node.querySelector(".control_block");
-
-                        const btns = controlBlock.querySelectorAll("a");
-                        const [upvote, downvote, funny] = btns;
-
-                        for (const btn of btns) {
-                            btn.href = "javascript:void(0)"; // eslint-disable-line no-script-url
-                        }
-
-                        /* eslint-disable new-cap, no-undef */
-                        upvote.onclick = () => UserReviewVoteUp(id);
-                        downvote.onclick = () => UserReviewVoteDown(id);
-                        funny.onclick = () => UserReviewVoteTag(id, 1, `RecommendationVoteTagBtn${id}_1`);
-                        /* eslint-enable new-cap, no-undef */
-                    }
-                });
-            }, [displayedReviews.map(review => review.id)]);
-        }
+        this._curPage = new URLSearchParams(window.location.search).get("p") || 1;
+        this._pageCount = 10;
 
         Messenger.addMessageListener("updateReview", id => {
-            Background.action("updatereviewnode", steamId, document.querySelector(`[id$="${id}"`).closest(".review_box").outerHTML, numReviews).then(getReviews);
+            Background.action("updatereviewnode", this._path, document.querySelector(`[id$="${id}"`).closest(".review_box").outerHTML, this._numReviews)
+                .then(() => { this._getReviews(); });
         });
 
         Page.runInPageContext(() => {
@@ -163,23 +35,140 @@ export default class FReviewSort extends Feature {
             });
         });
 
-        document.querySelector(".review_list h1").insertAdjacentElement(
-            "beforebegin",
-            Sortbox.get(
-                "reviews",
-                [
-                    ["default", Localization.str.date],
-                    ["rating", Localization.str.rating],
-                    ["helpful", Localization.str.helpful],
-                    ["funny", Localization.str.funny],
-                    ["length", Localization.str.length],
-                    ["visibility", Localization.str.visibility],
-                    ["playtime", Localization.str.playtime],
-                ],
-                SyncedStorage.get("sortreviewsby"),
-                sortReviews.bind(this),
-                "sortreviewsby"
-            )
-        );
+        document.querySelector("#leftContents > h1").before(Sortbox.get(
+            "reviews",
+            [
+                ["default", Localization.str.date],
+                ["rating", Localization.str.rating],
+                ["helpful", Localization.str.helpful],
+                ["funny", Localization.str.funny],
+                ["length", Localization.str.length],
+                ["visibility", Localization.str.visibility],
+                ["playtime", Localization.str.playtime],
+            ],
+            SyncedStorage.get("sortreviewsby"),
+            (sortBy, reversed) => { this._sortReviews(sortBy, reversed); },
+            "sortreviewsby"
+        ));
+    }
+
+    async _sortReviews(sortBy, reversed) {
+
+        if (!this._reviews) {
+            await this._getReviews();
+        }
+
+        for (const node of document.querySelectorAll(".review_box")) {
+            node.remove();
+        }
+
+        let displayedReviews = this._reviews.sort((a, b) => {
+            switch (sortBy) {
+                case "rating":
+                case "helpful":
+                case "funny":
+                case "length":
+                case "playtime":
+                    return b[sortBy] - a[sortBy];
+                case "visibility": {
+                    const _a = a[sortBy].toLowerCase();
+                    const _b = b[sortBy].toLowerCase();
+                    if (_a > _b) { return -1; }
+                    if (_a < _b) { return 1; }
+                    return 0;
+                }
+                case "default":
+                    return a[sortBy] - b[sortBy];
+                default:
+                    this.logError(
+                        new Error("Invalid sorting criteria"),
+                        "Can't sort reviews by criteria '%s'",
+                        sortBy,
+                    );
+                    return 0;
+            }
+        });
+
+        if (reversed) {
+            displayedReviews.reverse();
+        }
+
+        displayedReviews = displayedReviews.slice(this._pageCount * (this._curPage - 1), this._pageCount * this._curPage);
+
+        const footer = document.querySelector("#leftContents > .workshopBrowsePaging:last-child");
+        for (const {node} of displayedReviews) {
+            HTML.beforeBegin(footer, node);
+        }
+
+        // Add back sanitized event handlers
+        Page.runInPageContext(ids => {
+            document.querySelectorAll(".review_box").forEach((node, i) => {
+                const id = ids[i];
+
+                // Only exists when the requested profile is yours
+                const containers = node.querySelectorAll(".dselect_container");
+
+                if (containers.length > 0) {
+                    for (const container of containers) {
+                        const type = container.id.startsWith("ReviewVisibility") ? "Visibility" : "Language";
+                        const input = container.querySelector("input");
+                        const trigger = container.querySelector(".trigger");
+                        const selections = container.querySelectorAll(".dropcontainer a");
+
+                        input.onchange = () => { window[`OnReview${type}Change`](id, `Review${type}${id}`); };
+
+                        /* eslint-disable no-script-url, no-undef, new-cap, no-loop-func --
+                         * The D* functions are not actual references in this context,
+                         * they're functions in the page context. */
+                        trigger.href = "javascript:DSelectNoop();";
+                        trigger.onfocus = () => DSelectOnFocus(`Review${type}${id}`);
+                        trigger.onblur = () => DSelectOnBlur(`Review${type}${id}`);
+                        trigger.onclick = () => DSelectOnTriggerClick(`Review${type}${id}`);
+
+                        selections.forEach((selection, selIndex) => {
+                            selection.href = "javascript:DSelectNoop();";
+                            selection.onmouseover = () => DHighlightItem(`Review${type}${id}`, selIndex, false);
+                            selection.onclick = () => DHighlightItem(`Review${type}${id}`, selIndex, true);
+                        });
+                        /* eslint-enable no-script-url, no-undef, new-cap, no-loop-func */
+                    }
+
+                // Otherwise you have buttons to vote for the review
+                } else {
+                    const btns = node.querySelectorAll(".control_block a");
+                    const [upvote, downvote, funny] = btns;
+
+                    for (const btn of btns) {
+                        btn.href = "javascript:void(0)"; // eslint-disable-line no-script-url
+                    }
+
+                    /* eslint-disable new-cap, no-undef */
+                    upvote.onclick = () => UserReviewVoteUp(id);
+                    downvote.onclick = () => UserReviewVoteDown(id);
+                    funny.onclick = () => UserReviewVoteTag(id, 1, `RecommendationVoteTagBtn${id}_1`);
+                    /* eslint-enable new-cap, no-undef */
+                }
+            });
+        }, [displayedReviews.map(review => review.id)]);
+    }
+
+    async _getReviews() {
+
+        // Delay half a second to avoid dialog flicker when grabbing cache
+        await TimeUtils.timer(500);
+
+        Page.runInPageContext((processing, wait) => {
+            window.SteamFacade.showBlockingWaitDialog(processing, wait);
+        }, [Localization.str.processing, Localization.str.wait]);
+
+        try {
+            this._reviews = await Background.action("reviews", this._path, this._numReviews);
+
+            this._reviews.forEach((review, i) => { review.default = i; });
+        } finally {
+            Page.runInPageContext(() => {
+                window.SteamFacade.dismissActiveModal();
+            });
+        }
     }
 }

--- a/src/js/Content/Features/Community/Recommended/FReviewSort.js
+++ b/src/js/Content/Features/Community/Recommended/FReviewSort.js
@@ -5,15 +5,21 @@ import {Page} from "../../Page";
 export default class FReviewSort extends Feature {
 
     checkPrerequisites() {
+        // Total number of reviews. Passed to background script for fetching reviews.
         this._reviewCount = Number(document.querySelector("#rightContents .review_stat .giantNumber").textContent.trim());
+
         return this._reviewCount > 1;
     }
 
     apply() {
 
+        // Current profile path. Passed to background script for fetching reviews.
         this._path = window.location.pathname.match(/\/((?:id|profiles)\/.+?)\//)[1];
 
+        // Current page. Used to calculate the portion of reviews to show after sorting.
         this._curPage = new URLSearchParams(window.location.search).get("p") || 1;
+
+        // Max reviews displayed per page. Used for fetching reviews and synced with background script.
         this._pageCount = 10;
 
         Messenger.addMessageListener("updateReview", id => {
@@ -54,7 +60,7 @@ export default class FReviewSort extends Feature {
 
     async _sortReviews(sortBy, reversed) {
 
-        if (!this._reviews) {
+        if (typeof this._reviews === "undefined") {
             await this._getReviews();
         }
 

--- a/src/js/Content/Features/Community/Recommended/FReviewSort.js
+++ b/src/js/Content/Features/Community/Recommended/FReviewSort.js
@@ -154,9 +154,6 @@ export default class FReviewSort extends Feature {
 
     async _getReviews() {
 
-        // Delay half a second to avoid dialog flicker when grabbing cache
-        await TimeUtils.timer(500);
-
         Page.runInPageContext((processing, wait) => {
             window.SteamFacade.showBlockingWaitDialog(processing, wait);
         }, [Localization.str.processing, Localization.str.wait]);
@@ -166,6 +163,10 @@ export default class FReviewSort extends Feature {
 
             this._reviews.forEach((review, i) => { review.default = i; });
         } finally {
+
+            // Delay half a second to avoid dialog flicker when grabbing cache
+            await TimeUtils.timer(500);
+
             Page.runInPageContext(() => {
                 window.SteamFacade.dismissActiveModal();
             });

--- a/src/js/Content/Features/Community/Recommended/FReviewSort.js
+++ b/src/js/Content/Features/Community/Recommended/FReviewSort.js
@@ -30,7 +30,7 @@ export default class FReviewSort extends Feature {
                     || pathname.startsWith("/userreviews/update/")) {
 
                     const id = pathname.split("/").pop();
-                    Messenger.postMessage("updateReview", id);
+                    window.Messenger.postMessage("updateReview", id);
                 }
             });
         });

--- a/src/js/Content/Features/Community/Recommended/FReviewSort.js
+++ b/src/js/Content/Features/Community/Recommended/FReviewSort.js
@@ -58,7 +58,7 @@ export default class FReviewSort extends Feature {
             await this._getReviews();
         }
 
-        for (const node of document.querySelectorAll(".review_box")) {
+        for (const node of document.querySelectorAll(".review_box, .review_developer_response_container")) {
             node.remove();
         }
 

--- a/src/js/Content/Features/Community/Recommended/FReviewSort.js
+++ b/src/js/Content/Features/Community/Recommended/FReviewSort.js
@@ -45,6 +45,7 @@ export default class FReviewSort extends Feature {
                 ["length", Localization.str.length],
                 ["visibility", Localization.str.visibility],
                 ["playtime", Localization.str.playtime],
+                ["awards", Localization.str.awards],
             ],
             SyncedStorage.get("sortreviewsby"),
             (sortBy, reversed) => { this._sortReviews(sortBy, reversed); },
@@ -70,6 +71,7 @@ export default class FReviewSort extends Feature {
                 case "length":
                 case "visibility":
                 case "playtime":
+                case "awards":
                     return b[sortBy] - a[sortBy];
                 case "default":
                     return a[sortBy] - b[sortBy];

--- a/src/js/Content/Features/Community/Recommended/FReviewSort.js
+++ b/src/js/Content/Features/Community/Recommended/FReviewSort.js
@@ -5,20 +5,19 @@ import {Page} from "../../Page";
 export default class FReviewSort extends Feature {
 
     checkPrerequisites() {
-        return document.querySelectorAll(".review_box").length > 1;
+        this._reviewCount = Number(document.querySelector("#rightContents .review_stat .giantNumber").textContent.trim());
+        return this._reviewCount > 1;
     }
 
     apply() {
 
-        const pagingInfo = document.querySelector(".workshopBrowsePagingInfo").textContent;
-        this._numReviews = Math.max(...pagingInfo.replace(/,/g, "").match(/\d+/g));
         this._path = window.location.pathname.match(/\/((?:id|profiles)\/.+?)\//)[1];
 
         this._curPage = new URLSearchParams(window.location.search).get("p") || 1;
         this._pageCount = 10;
 
         Messenger.addMessageListener("updateReview", id => {
-            Background.action("updatereviewnode", this._path, document.querySelector(`[id$="${id}"`).closest(".review_box").outerHTML, this._numReviews)
+            Background.action("updatereviewnode", this._path, document.querySelector(`[id$="${id}"`).closest(".review_box").outerHTML, this._reviewCount)
                 .then(() => { this._getReviews(); });
         });
 
@@ -161,7 +160,7 @@ export default class FReviewSort extends Feature {
         }, [Localization.str.processing, Localization.str.wait]);
 
         try {
-            this._reviews = await Background.action("reviews", this._path, this._numReviews);
+            this._reviews = await Background.action("reviews", this._path, this._reviewCount);
         } finally {
 
             // Delay half a second to avoid dialog flicker when grabbing cache

--- a/src/js/Content/Features/Community/Recommended/FReviewSort.js
+++ b/src/js/Content/Features/Community/Recommended/FReviewSort.js
@@ -160,8 +160,6 @@ export default class FReviewSort extends Feature {
 
         try {
             this._reviews = await Background.action("reviews", this._path, this._numReviews);
-
-            this._reviews.forEach((review, i) => { review.default = i; });
         } finally {
 
             // Delay half a second to avoid dialog flicker when grabbing cache

--- a/src/js/Content/Features/Community/Recommended/FReviewSort.js
+++ b/src/js/Content/Features/Community/Recommended/FReviewSort.js
@@ -68,15 +68,9 @@ export default class FReviewSort extends Feature {
                 case "helpful":
                 case "funny":
                 case "length":
+                case "visibility":
                 case "playtime":
                     return b[sortBy] - a[sortBy];
-                case "visibility": {
-                    const _a = a[sortBy].toLowerCase();
-                    const _b = b[sortBy].toLowerCase();
-                    if (_a > _b) { return -1; }
-                    if (_a < _b) { return 1; }
-                    return 0;
-                }
                 case "default":
                     return a[sortBy] - b[sortBy];
                 default:

--- a/src/js/Content/Features/Community/Recommended/FReviewSort.js
+++ b/src/js/Content/Features/Community/Recommended/FReviewSort.js
@@ -62,7 +62,7 @@ export default class FReviewSort extends Feature {
             node.remove();
         }
 
-        let displayedReviews = this._reviews.sort((a, b) => {
+        let displayedReviews = this._reviews.slice().sort((a, b) => {
             switch (sortBy) {
                 case "rating":
                 case "helpful":

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -350,6 +350,7 @@
     "sort_by": "Sort by:",
     "sort_by_keyword": "Sort by __keyword__",
     "playtime": "Playtime",
+    "awards": "Awards",
     "year": "Year",
     "lastonline": "Last Online",
     "members": "Members",


### PR DESCRIPTION
Fixes #1526.

TODO
1. `SteamCommunityApi.updateReviewNode` only updates the node, but we need to update helpful, funny, visibility, and (the newly introduced) awards data too. The page reloads after giving an award though...
2. Reviews are cached for an hour, but may contain outdated data, especially after Steam introduced content checking. Maybe there should be a "force update" feature?
3. There're no doubt more cases to handle, e.g. developer or support accounts that have the ability to reply to or flag reviews. No idea what to do until somebody raises an issue.