### PR TITLE
FReviewSort: Patch award nodes and callback; improve background action after updating reviews

### DIFF
--- a/src/js/Background/background.js
+++ b/src/js/Background/background.js
@@ -86,7 +86,6 @@ const actionCallbacks = new Map([
     ["clearownprofile", SteamCommunityApi.clearOwn],
     ["workshopfilesize", SteamCommunityApi.getWorkshopFileSize],
     ["reviews", SteamCommunityApi.getReviews],
-    ["updatereviewnode", SteamCommunityApi.updateReviewNode],
 
     ["itad.authorize", ITADApi.authorize],
     ["itad.disconnect", ITADApi.disconnect],


### PR DESCRIPTION
Follow-up to #1619.

1. Turns out the page reloading after giving an award is just Steam being lazy, so this patches `OnUserReviewAward` to match the behaviour on games pages, forums etc.
2. `updateReviewNode` backgound action is not really working most of the time, and would take too much effort to fix just for the sake of avoiding outdated data during the 1 hour cache period. First off, it only updates the node, when it should handle stats changes too. But unfortunately most stats changes are not reflected in the DOM (only awards and visibility do). It's also unable to update dev response nodes, since it's not part of the review node and will require parsing the whole page. Lastly, this action causes us to fetch reviews after voting, awarding a review etc. whether the user likes it or not, and could be rather disruptive esp. if there're many pages to load. So this changes it to force fetch reviews when the user selects a sort method _after_ having performed an action that may update review stats.