### PR TITLE
Fix wishlist observer

### DIFF
--- a/src/js/Content/Features/Store/Wishlist/CWishlist.js
+++ b/src/js/Content/Features/Store/Wishlist/CWishlist.js
@@ -75,15 +75,14 @@ export class CWishlist extends CStoreBase {
 
     _registerObserver() {
 
-        const container = document.getElementById("wishlist_ctn");
         let timer = null;
         const delayedWork = new Set();
 
         new MutationObserver(mutations => {
 
-            for (const record of mutations) {
-                if (record.addedNodes.length === 1) {
-                    delayedWork.add(record.addedNodes[0]);
+            for (const {addedNodes} of mutations) {
+                if (addedNodes[0]) {
+                    delayedWork.add(addedNodes[0]);
                 }
             }
 
@@ -92,14 +91,16 @@ export class CWishlist extends CStoreBase {
                 timer = TimeUtils.resettableTimer(() => {
 
                     // Valve detaches wishlist entries that aren't visible
-                    const arg = Array.from(delayedWork).filter(node => node.parentNode === container);
+                    const visibleRows = Array.from(delayedWork).filter(node => node.isConnected);
                     delayedWork.clear();
 
-                    this.triggerCallbacks(arg);
+                    if (visibleRows.length !== 0) {
+                        this.triggerCallbacks(visibleRows);
+                    }
                 }, 50);
             } else {
                 timer.reset();
             }
-        }).observe(container, {"childList": true});
+        }).observe(document.getElementById("wishlist_ctn"), {"childList": true});
     }
 }

--- a/src/js/Content/Features/Store/Wishlist/FKeepEditableRanking.js
+++ b/src/js/Content/Features/Store/Wishlist/FKeepEditableRanking.js
@@ -44,8 +44,6 @@ export default class FKeepEditableRanking extends CallbackFeature {
 
         for (const node of nodes) {
 
-            if (node.querySelector(".as_hover_handle") !== null) { continue; }
-
             // Clone the hover element in order to disable drag-and-drop while filtering is active
             const hoverHandle = node.querySelector(".hover_handle");
             const newHoverHandle = hoverHandle.cloneNode(true);

--- a/src/js/Content/Features/Store/Wishlist/FOneClickRemoveFromWishlist.js
+++ b/src/js/Content/Features/Store/Wishlist/FOneClickRemoveFromWishlist.js
@@ -13,11 +13,9 @@ export default class FOneClickRemoveFromWishlist extends CallbackFeature {
         for (const node of nodes) {
 
             const deleteNode = node.querySelector(".delete");
-            if (deleteNode.classList.contains("as-oneclickremove")) { continue; }
 
             // Replace the delete node in order to disable Steam's handlers
             const newDeleteNode = deleteNode.cloneNode(true);
-            newDeleteNode.classList.add("as-oneclickremove");
             deleteNode.replaceWith(newDeleteNode);
 
             // eslint-disable-next-line no-loop-func

--- a/src/js/Content/Features/Store/Wishlist/FWishlistUserNotes.js
+++ b/src/js/Content/Features/Store/Wishlist/FWishlistUserNotes.js
@@ -62,6 +62,9 @@ export default class FWishlistUserNotes extends CallbackFeature {
             // Adjust the row height to account for the newly added note content
             wl.nRowHeight = f.jq(".wishlist_row").outerHeight(true);
 
+            // Update initial container height
+            document.getElementById("wishlist_ctn").style.height = `${wl.nRowHeight * wl.rgVisibleApps.length}px`;
+
             // The scroll handler loads the visible rows and adjusts their positions
             f.wishlistOnScroll();
         }, [Localization.str.user_note.add]);

--- a/src/js/Content/Features/Store/Wishlist/FWishlistUserNotes.js
+++ b/src/js/Content/Features/Store/Wishlist/FWishlistUserNotes.js
@@ -71,20 +71,15 @@ export default class FWishlistUserNotes extends CallbackFeature {
     }
 
     async callback(nodes) {
-        const newNodes = nodes.filter(node => !node.classList.contains("js-note-checked"));
 
-        for (const node of newNodes) {
-            node.classList.add("js-note-checked");
-        }
-
-        const appids = newNodes.map(node => Number(node.dataset.appId));
+        const appids = nodes.map(node => Number(node.dataset.appId));
         const notes = await this._userNotes.get(appids);
 
-        for (let i = 0; i < newNodes.length; i++) {
+        for (let i = 0; i < nodes.length; i++) {
             const note = notes[appids[i]];
 
             if (typeof note !== "undefined") {
-                const noteEl = newNodes[i].querySelector(".esi-note");
+                const noteEl = nodes[i].querySelector(".esi-note");
                 noteEl.textContent = `"${note}"`;
                 noteEl.classList.add("esi-has-note");
             }


### PR DESCRIPTION
1. Steam introduced a bug in their changes: https://github.com/SteamDatabase/SteamTracking/blob/fad88f22ab535c83349243be1f8f83dddbf61557/store.steampowered.com/public/javascript/wishlist.js#L331, should use `+=` because there's a closing tag blow. This causes jQuery to render an additonal text node. For testing:
```js
$J('<div class="purchase_container" >\r\n\t\t\t\t\t\t</div>\r\n\t\t\t\t\t</div>')
```

2. Fixup 29bd5012e905997f7b90f189a5ea7324d8a3b73f. We also need to update the initial container height (which is done through `g_Wishlist.Update()`) because it changes the scroll area, and is used to calculate what elements to load/unload. Without this there'll be weird issues if you scroll to the bottom.

3. Avoid having to manually check which nodes have been processed already for every feature.