### PR TITLE
Simplify DynamicStore

### DIFF
--- a/src/js/Background/Modules/SteamStoreApi.js
+++ b/src/js/Background/Modules/SteamStoreApi.js
@@ -175,14 +175,6 @@ class SteamStoreApi extends Api {
             "wishlisted": rgWishlist,
         };
 
-        /*
-         * dynamicstore keys are:
-         * "rgWishlist", "rgOwnedPackages", "rgOwnedApps", "rgPackagesInCart", "rgAppsInCart"
-         * "rgRecommendedTags", "rgIgnoredApps", "rgIgnoredPackages", "rgCurators", "rgCurations"
-         * "rgCreatorsFollowed", "rgCreatorsIgnored", "preferences", "rgExcludedTags",
-         * "rgExcludedContentDescriptorIDs", "rgAutoGrantApps"
-         */
-
         return IndexedDB.put("dynamicStore", dynamicStore);
     }
 

--- a/src/js/Background/Modules/SteamStoreApi.js
+++ b/src/js/Background/Modules/SteamStoreApi.js
@@ -184,7 +184,7 @@ class SteamStoreApi extends Api {
 
     static async dynamicStoreRandomApp() {
         const store = await IndexedDB.getAll("dynamicStore");
-        if (!store || !store.ownedApps) { return null; }
+        if (!store.ownedApps.length) { return null; }
         return store.ownedApps[Math.floor(Math.random() * store.ownedApps.length)];
     }
 

--- a/src/js/Background/background.js
+++ b/src/js/Background/background.js
@@ -70,8 +70,8 @@ const actionCallbacks = new Map([
     ["wishlists", SteamStoreApi.wishlists],
     ["purchases", SteamStoreApi.purchases],
     ["clearpurchases", SteamStoreApi.clearPurchases],
-    ["dynamicstorestatus", SteamStoreApi.dsStatus],
-    ["dynamicStore.randomApp", SteamStoreApi.dynamicStoreRandomApp],
+    ["dynamicstore.status", SteamStoreApi.dsStatus],
+    ["dynamicstore.randomapp", SteamStoreApi.dynamicStoreRandomApp],
 
     ["login", SteamCommunityApi.login],
     ["logout", SteamCommunityApi.logout],

--- a/src/js/Content/Modules/Data/DynamicStore.js
+++ b/src/js/Content/Modules/Data/DynamicStore.js
@@ -20,7 +20,7 @@ class DynamicStore {
         const storeIds = multiple ? storeId : [storeId];
         const trimmedIds = storeIds.map(id => GameId.trimStoreId(id));
 
-        const dsStatus = await Background.action("dynamicstorestatus", trimmedIds);
+        const dsStatus = await Background.action("dynamicstore.status", trimmedIds);
 
         const status = storeIds.reduce((acc, id, i) => {
             const trimmedId = trimmedIds[i];
@@ -41,7 +41,7 @@ class DynamicStore {
 
     static async getRandomApp() {
         await DynamicStore._fetch();
-        return Background.action("dynamicStore.randomApp");
+        return Background.action("dynamicstore.randomapp");
     }
 
     static _fetch() {

--- a/src/js/Content/Modules/Data/DynamicStore.js
+++ b/src/js/Content/Modules/Data/DynamicStore.js
@@ -1,15 +1,7 @@
 import {GameId} from "../../../Core/GameId";
 import {Background} from "../Background";
-import {User} from "../User";
 
 class DynamicStore {
-
-    /*
-     * FIXME
-     *  1. Check usage of `await DynamicStore`, currently it does nothing
-     *  2. getAppStatus() is not properly waiting for initialization of the DynamicStore
-     *  3. There is no guarante that `User` is initialized before `_fetch()` is called
-     */
 
     static clear() {
         return Background.action("dynamicstore.clear");
@@ -39,23 +31,8 @@ class DynamicStore {
         return multiple ? status : status[storeId];
     }
 
-    static async getRandomApp() {
-        await DynamicStore._fetch();
+    static getRandomApp() {
         return Background.action("dynamicstore.randomapp");
-    }
-
-    static _fetch() {
-        if (!User.isSignedIn) {
-            return DynamicStore.clear();
-        }
-        return Promise.resolve(null);
-    }
-
-    static then(onDone, onCatch) {
-        if (!DynamicStore._promise) {
-            DynamicStore._promise = DynamicStore._fetch();
-        }
-        return DynamicStore._promise.then(onDone, onCatch);
     }
 }
 

--- a/src/js/Content/Modules/Data/DynamicStore.js
+++ b/src/js/Content/Modules/Data/DynamicStore.js
@@ -9,7 +9,6 @@ class DynamicStore {
      *  1. Check usage of `await DynamicStore`, currently it does nothing
      *  2. getAppStatus() is not properly waiting for initialization of the DynamicStore
      *  3. There is no guarante that `User` is initialized before `_fetch()` is called
-     *  4. getAppStatus() should probably be simplified if we force array even when only one storeId was requested
      */
 
     static clear() {
@@ -18,47 +17,26 @@ class DynamicStore {
 
     static async getAppStatus(storeId) {
         const multiple = Array.isArray(storeId);
-        let promise;
-        let trimmedIds;
+        const storeIds = multiple ? storeId : [storeId];
+        const trimmedIds = storeIds.map(id => GameId.trimStoreId(id));
 
-        if (multiple) {
-            trimmedIds = storeId.map(id => GameId.trimStoreId(id));
-            promise = Background.action("dynamicstorestatus", trimmedIds);
-        } else {
-            promise = Background.action("dynamicstorestatus", GameId.trimStoreId(storeId));
-        }
+        const dsStatus = await Background.action("dynamicstorestatus", trimmedIds);
 
-        let statusList;
-        const dsStatusList = await promise;
-
-        if (multiple) {
-            statusList = {};
-            for (let i = 0; i < storeId.length; ++i) {
-                const trimmedId = trimmedIds[i];
-                const id = storeId[i];
-                statusList[id] = {
-                    "ignored": dsStatusList[trimmedId].includes("ignored"),
-                    "wishlisted": dsStatusList[trimmedId].includes("wishlisted"),
-                };
-                if (id.startsWith("app/")) {
-                    statusList[id].owned = dsStatusList[trimmedId].includes("ownedApps");
-                } else if (id.startsWith("sub/")) {
-                    statusList[id].owned = dsStatusList[trimmedId].includes("ownedPackages");
-                }
-            }
-        } else {
-            statusList = {
-                "ignored": dsStatusList.includes("ignored"),
-                "wishlisted": dsStatusList.includes("wishlisted"),
+        const status = storeIds.reduce((acc, id, i) => {
+            const trimmedId = trimmedIds[i];
+            acc[id] = {
+                "ignored": dsStatus[trimmedId].includes("ignored"),
+                "wishlisted": dsStatus[trimmedId].includes("wishlisted"),
             };
-            if (storeId.startsWith("app/")) {
-                statusList.owned = dsStatusList.includes("ownedApps");
-            } else if (storeId.startsWith("sub/")) {
-                statusList.owned = dsStatusList.includes("ownedPackages");
+            if (id.startsWith("app/")) {
+                acc[id].owned = dsStatus[trimmedId].includes("ownedApps");
+            } else if (id.startsWith("sub/")) {
+                acc[id].owned = dsStatus[trimmedId].includes("ownedPackages");
             }
-        }
+            return acc;
+        }, {});
 
-        return statusList;
+        return multiple ? status : status[storeId];
     }
 
     static async getRandomApp() {


### PR DESCRIPTION
1. Removed a bunch of outdated stuff: `await DynamicStore` isn't used anywhere, and `getAppStatus()` calls into indexedDB which checks the expiry.
2. `_fetch()` is only called in `getRandomApp()`, which is already guarded by `User.isSignedIn` in `AugmentedSteam.js`. Maybe we should "force fetch" dynamic store data in this case?