### PR TITLE
Simplify post request body content type

### DIFF
--- a/src/js/Background/Modules/Api.js
+++ b/src/js/Background/Modules/Api.js
@@ -9,7 +9,9 @@ class Api {
      * withResponse? use a boolean to include Response object in result?
      */
     static _fetchWithDefaults(endpoint, query = {}, params = {}) {
-        const url = new URL(endpoint, this.origin);
+        // AS APIs require trailing slash
+        const _endpoint = endpoint.endsWith("/") ? endpoint : endpoint + "/";
+        const url = new URL(_endpoint, this.origin);
         const _params = {...this.params, ...params};
         if (_params.method === "POST" && !_params.body) {
             _params.body = new URLSearchParams(query);
@@ -20,10 +22,7 @@ class Api {
     }
 
     static async getEndpoint(endpoint, query, responseHandler, params = {}) {
-        let _endpoint = endpoint;
-        if (!endpoint.endsWith("/")) { _endpoint += "/"; }
-
-        const response = await this._fetchWithDefaults(_endpoint, query, Object.assign(params, {"method": "GET"}));
+        const response = await this._fetchWithDefaults(endpoint, query, Object.assign(params, {"method": "GET"}));
         if (responseHandler) { responseHandler(response); }
         return response.json();
     }
@@ -35,19 +34,13 @@ class Api {
     }
 
     static async postEndpoint(endpoint, query, responseHandler, params = {}) {
-        let _endpoint = endpoint;
-        if (!endpoint.endsWith("/")) { _endpoint += "/"; }
-
-        const response = await this._fetchWithDefaults(_endpoint, query, Object.assign(params, {"method": "POST"}));
+        const response = await this._fetchWithDefaults(endpoint, query, Object.assign(params, {"method": "POST"}));
         if (responseHandler) { responseHandler(response); }
         return response.json();
     }
 
     static async deleteEndpoint(endpoint, query, responseHandler, params = {}) {
-        let _endpoint = endpoint;
-        if (!endpoint.endsWith("/")) { _endpoint += "/"; }
-
-        const response = await this._fetchWithDefaults(_endpoint, query, Object.assign(params, {"method": "DELETE"}));
+        const response = await this._fetchWithDefaults(endpoint, query, Object.assign(params, {"method": "DELETE"}));
         if (responseHandler) { responseHandler(response); }
         return response.json();
     }

--- a/src/js/Background/Modules/Api.js
+++ b/src/js/Background/Modules/Api.js
@@ -11,16 +11,10 @@ class Api {
     static _fetchWithDefaults(endpoint, query = {}, params = {}) {
         const url = new URL(endpoint, this.origin);
         const _params = {...this.params, ...params};
-        if (_params && _params.method === "POST" && !_params.body) {
-            const formData = new FormData();
-            for (const [k, v] of Object.entries(query)) {
-                formData.append(k, v);
-            }
-            _params.body = formData;
+        if (_params.method === "POST" && !_params.body) {
+            _params.body = new URLSearchParams(query);
         } else {
-            for (const [k, v] of Object.entries(query)) {
-                url.searchParams.append(k, v);
-            }
+            url.search = new URLSearchParams(query).toString();
         }
         return fetch(url, _params);
     }

--- a/src/js/Content/Features/Community/Badges/CBadges.js
+++ b/src/js/Content/Features/Community/Badges/CBadges.js
@@ -32,7 +32,7 @@ export class CBadges extends CCommunityBase {
             url.searchParams.set("p", p);
 
             try {
-                const response = await RequestData.getHttp(url.toString());
+                const response = await RequestData.getHttp(url);
 
                 const delayedLoadImages = HTMLParser.getVariableFromText(response, "g_rgDelayedLoadImages", "object");
                 const dom = HTML.toDom(response);

--- a/src/js/Content/Features/Community/FriendsAndGroups/FGroupsManageButton.js
+++ b/src/js/Content/Features/Community/FriendsAndGroups/FGroupsManageButton.js
@@ -80,6 +80,7 @@ export default class FGroupsManageButton extends CallbackFeature {
     }
 
     async _leaveGroups() {
+        this._endpoint = new URL("friends/action", User.profileUrl);
         const selected = [];
 
         for (const group of document.querySelectorAll(".group_block.selected")) {
@@ -136,6 +137,6 @@ export default class FGroupsManageButton extends CallbackFeature {
             "steamids[]": id
         };
 
-        return RequestData.post(`${User.profileUrl}/friends/action`, data, {}, true);
+        return RequestData.post(this._endpoint, data, {}, true);
     }
 }

--- a/src/js/Content/Features/Community/FriendsAndGroups/FGroupsManageButton.js
+++ b/src/js/Content/Features/Community/FriendsAndGroups/FGroupsManageButton.js
@@ -128,13 +128,14 @@ export default class FGroupsManageButton extends CallbackFeature {
     }
 
     _leaveGroup(id) {
-        const formData = new FormData();
-        formData.append("sessionid", User.sessionId);
-        formData.append("steamid", User.steamId);
-        formData.append("ajax", 1);
-        formData.append("action", "leave_group");
-        formData.append("steamids[]", id);
+        const data = {
+            "sessionid": User.sessionId,
+            "steamid": User.steamId,
+            "ajax": 1,
+            "action": "leave_group",
+            "steamids[]": id
+        };
 
-        return RequestData.post(`${User.profileUrl}/friends/action`, formData, {}, true);
+        return RequestData.post(`${User.profileUrl}/friends/action`, data, {}, true);
     }
 }

--- a/src/js/Content/Features/Community/Inventory/FEquipProfileItems.js
+++ b/src/js/Content/Features/Community/Inventory/FEquipProfileItems.js
@@ -53,22 +53,19 @@ export default class FEquipProfileItems extends CallbackFeature {
             if (btn.classList.contains("es_equip_loading") || btn.classList.contains("btn_disabled")) { return; }
             btn.classList.add("es_equip_loading");
 
-            const formData = new FormData();
-
             /*
              * Note: For duplicate items, assetId won't be the same, and the /IPlayerService/GetProfileItemsOwned/ endpoint
              * will only return one of them (the first one obtained maybe?), but any of them will work for equipping.
              */
-            formData.append("communityitemid", assetId);
+            const data = {"communityitemid": assetId};
 
             if (itemType === "profilemodifier") {
-                formData.append("appid", appid);
-                formData.append("activate", true);
+                Object.assign(data, {appid, "activate": true});
             }
 
             try {
                 const token = await User.accessToken;
-                await RequestData.post(`https://api.steampowered.com${apiPath}?access_token=${token}`, formData, {"credentials": "omit"});
+                await RequestData.post(`https://api.steampowered.com${apiPath}?access_token=${token}`, data, {"credentials": "omit"});
 
                 btn.classList.add("btn_disabled");
             } catch (err) {

--- a/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
+++ b/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
@@ -107,15 +107,16 @@ export default class FQuickSellOptions extends CallbackFeature {
             const sellPrice = feeInfo.amount - feeInfo.fees;
 
             // https://github.com/SteamDatabase/SteamTracking/blob/13e4e0c8f8772ef316f73881af8c546218cf7117/steamcommunity.com/public/javascript/economy_v2.js#L4268
-            const formData = new FormData();
-            formData.append("sessionid", sessionId);
-            formData.append("appid", globalId);
-            formData.append("contextid", contextId);
-            formData.append("assetid", assetId);
-            formData.append("amount", 1); // TODO support stacked items, e.g. sack of gems
-            formData.append("price", sellPrice);
+            const data = {
+                "sessionid": sessionId,
+                "appid": globalId,
+                "contextid": contextId,
+                "assetid": assetId,
+                "amount": 1, // TODO support stacked items, e.g. sack of gems
+                "price": sellPrice
+            };
 
-            const result = await RequestData.post("https://steamcommunity.com/market/sellitem/", formData, {}, true).catch(err => err);
+            const result = await RequestData.post("https://steamcommunity.com/market/sellitem/", data, {}, true).catch(err => err);
 
             if (!result?.success) {
                 loadingEl.textContent = result?.message ?? Localization.str.error;

--- a/src/js/Content/Features/Community/MyWorkshop/FWorkshopFileSizes.js
+++ b/src/js/Content/Features/Community/MyWorkshop/FWorkshopFileSizes.js
@@ -65,7 +65,7 @@ export default class FWorkshopFileSizes extends Feature {
         for (let p = 1; p <= Math.ceil(this._total / 30); p++) {
             url.searchParams.set("p", p);
 
-            const result = await RequestData.getHttp(url.toString()).catch(err => console.error(err));
+            const result = await RequestData.getHttp(url).catch(err => console.error(err));
             if (!result) {
                 console.error(`Failed to request ${url}`);
                 continue;

--- a/src/js/Content/Features/Community/ProfileStats/CProfileStats.js
+++ b/src/js/Content/Features/Community/ProfileStats/CProfileStats.js
@@ -27,7 +27,7 @@ export class CProfileStats extends CCommunityBase {
         url.searchParams.set("tab", "achievements");
         url.searchParams.set("panorama", "please");
 
-        return RequestData.getHttp(url.toString()).then(result => {
+        return RequestData.getHttp(url).then(result => {
             this._data = HTMLParser.getVariableFromText(result, "g_rgAchievements", "object");
             return this._data;
         });

--- a/src/js/Content/Features/Community/Workshop.js
+++ b/src/js/Content/Features/Community/Workshop.js
@@ -6,12 +6,9 @@ export default class Workshop {
 
         const _method = method === "subscribe" ? method : "unsubscribe";
 
-        const formData = new FormData();
-        formData.append("sessionid", User.sessionId);
-        formData.append("appid", appid);
-        formData.append("id", id);
+        const data = {"sessionid": User.sessionId, appid, id};
 
-        const res = await RequestData.post(`https://steamcommunity.com/sharedfiles/${_method}`, formData, {}, true);
+        const res = await RequestData.post(`https://steamcommunity.com/sharedfiles/${_method}`, data, {}, true);
 
         if (method === "subscribe") {
             // https://github.com/SteamDatabase/SteamTracking/blob/3ab40a4604426852de8a51c50d963978e9660de4/steamcommunity.com/public/javascript/sharedfiles_functions_logged_in.js#L533

--- a/src/js/Content/Features/Community/Workshop/FBrowseWorkshops.js
+++ b/src/js/Content/Features/Community/Workshop/FBrowseWorkshops.js
@@ -66,8 +66,8 @@ export default class FBrowseWorkshops extends Feature {
                 </div>
             </div>`);
 
-        const url = `https://steamcommunity.com/sharedfiles/ajaxgetworkshops/render/?query=${query}&start=${start}&count=${count}`;
-        const result = JSON.parse(await RequestData.getHttp(url));
+        const params = new URLSearchParams({query, start, count});
+        const result = await RequestData.getJson(`https://steamcommunity.com/sharedfiles/ajaxgetworkshops/render/?${params}`);
         HTML.inner(container, result.results_html);
 
         // Restore onclick attribute

--- a/src/js/Content/Features/Community/WorkshopBrowse/FWorkshopSubscriberButtons.js
+++ b/src/js/Content/Features/Community/WorkshopBrowse/FWorkshopSubscriberButtons.js
@@ -61,7 +61,7 @@ export default class FWorkshopSubscriberButtons extends Feature {
         for (let p = 1; p <= Math.ceil(this._total / 30); p++) {
             url.searchParams.set("p", p);
 
-            const result = await RequestData.getHttp(url.toString()).catch(err => console.error(err));
+            const result = await RequestData.getHttp(url).catch(err => console.error(err));
             if (!result) {
                 console.error(`Failed to request ${url}`);
                 continue;

--- a/src/js/Content/Features/Store/RegisterKey/FMultiProductKeys.js
+++ b/src/js/Content/Features/Store/RegisterKey/FMultiProductKeys.js
@@ -85,12 +85,13 @@ export default class FMultiProductKeys extends Feature {
             for (let i = 0; i < keys.length; i++) {
                 const currentKey = keys[i];
 
-                const formData = new FormData();
-                formData.append("sessionid", User.sessionId);
-                formData.append("product_key", currentKey);
+                const data = {
+                    "sessionid": User.sessionId,
+                    "product_key": currentKey
+                };
 
-                const request = RequestData.post("https://store.steampowered.com/account/ajaxregisterkey", formData).then(data => {
-                    const _data = JSON.parse(data);
+                const request = RequestData.post("https://store.steampowered.com/account/ajaxregisterkey", data).then(response => {
+                    const _data = JSON.parse(response);
                     const attempted = currentKey;
                     let message = Localization.str.register.default;
                     if (_data.success === 1) {

--- a/src/js/Content/Features/Store/Wishlist/FEmptyWishlist.js
+++ b/src/js/Content/Features/Store/Wishlist/FEmptyWishlist.js
@@ -42,11 +42,7 @@ export default class FEmptyWishlist extends Feature {
                     .replace("__cur__", cur++)
                     .replace("__total__", wishlistData.length);
 
-                const formData = new FormData();
-                formData.append("sessionid", User.sessionId);
-                formData.append("appid", appid);
-
-                await RequestData.post(url, formData);
+                await RequestData.post(url, {"sessionid": User.sessionId, appid});
             }
 
             DynamicStore.clear();

--- a/src/js/Content/Modules/RequestData.js
+++ b/src/js/Content/Modules/RequestData.js
@@ -39,12 +39,12 @@ class RequestData {
         return responseType === "none" ? response : response[responseType]();
     }
 
-    static post(url, formData, settings = {}, returnJSON = false) {
+    static post(url, data, settings = {}, returnJSON = false) {
 
         const _settings = {
             ...settings,
             "method": "POST",
-            "body": formData
+            "body": new URLSearchParams(data)
         };
 
         let _responseType;

--- a/src/js/Content/Modules/RequestData.js
+++ b/src/js/Content/Modules/RequestData.js
@@ -5,12 +5,6 @@ class RequestData {
 
     static async getHttp(url, settings = {}, responseType = "text") {
 
-        let _url = url;
-        if (_url.startsWith("//")) { // TODO remove when not needed
-            _url = window.location.protocol + url;
-            console.warn("Requesting URL without protocol, please update");
-        }
-
         const _settings = {
             "method": "GET",
             "credentials": "include",
@@ -24,7 +18,7 @@ class RequestData {
         let response;
 
         try {
-            response = await RequestData._fetchFn(_url, _settings);
+            response = await RequestData._fetchFn(url, _settings);
 
             if (!response.ok) {
                 throw new Errors.HTTPError(response.status, `HTTP ${response.status} ${response.statusText} for ${response.url}`);
@@ -55,7 +49,7 @@ class RequestData {
         } else {
             _responseType = "text";
         }
-        
+
         return RequestData.getHttp(url, _settings, _responseType);
     }
 
@@ -75,7 +69,7 @@ class RequestData {
  */
 RequestData._fetchFn
     // eslint-disable-next-line no-undef
-    = (typeof content !== "undefined" && content && content.fetch) // content is only available in FF environments
+    = (typeof content !== "undefined" && content && content.fetch)
     || fetch.bind(window);
 
 export {RequestData};


### PR DESCRIPTION
We're not sending files or blobs, so we don't really need to use `FormData`, a URL-encoded string will do. Also removed some URL checks that I think are redundant.