### PR TITLE
Remove some highlight player function patches

### DIFF
--- a/src/js/Content/Features/Community/ProfileActivity/CProfileActivity.js
+++ b/src/js/Content/Features/Community/ProfileActivity/CProfileActivity.js
@@ -6,7 +6,7 @@ import FHighlightFriendsActivity from "./FHighlightFriendsActivity";
 import FAchievementLink from "./FAchievementLink";
 import FReplaceCommunityHubLinks from "./FReplaceCommunityHubLinks";
 import FToggleComments from "./FToggleComments";
-import {Page} from "../../Page";
+import FPatchBlotterFunc from "./FPatchBlotterFunc";
 
 export class CProfileActivity extends CCommunityBase {
 
@@ -17,27 +17,10 @@ export class CProfileActivity extends CCommunityBase {
             FAchievementLink,
             FReplaceCommunityHubLinks,
             FToggleComments,
+            FPatchBlotterFunc,
         ]);
 
-        this._registerObserver();
-
-        // Fix undefined function when clicking on the "show all x comments" button under "uploaded a screenshot" type activity
-        Page.runInPageContext(() => {
-            const f = window.SteamFacade;
-
-            if (typeof f.global("Blotter_ShowLargeScreenshot") !== "function") {
-
-                f.globalSet("Blotter_ShowLargeScreenshot", (galleryid, showComments) => {
-                    const gallery = f.global("g_BlotterGalleries")[galleryid];
-                    const ss = gallery.shots[gallery.m_screenshotActive];
-                    f.showModalContent(`${ss.m_modalContentLink}&insideModal=1&showComments=${showComments}`, ss.m_modalContentLinkText, ss.m_modalContentLink, true);
-                });
-            }
-        });
-    }
-
-    _registerObserver() {
-
+        // Process newly added activity entries
         new MutationObserver(mutations => {
             for (const {addedNodes} of mutations) {
                 this.triggerCallbacks(addedNodes[0]);

--- a/src/js/Content/Features/Community/ProfileActivity/FPatchBlotterFunc.js
+++ b/src/js/Content/Features/Community/ProfileActivity/FPatchBlotterFunc.js
@@ -1,0 +1,22 @@
+import {Feature} from "../../../modulesContent";
+import {Page} from "../../Page";
+
+export default class FPatchBlotterFunc extends Feature {
+
+    apply() {
+
+        // Fix undefined function when clicking on the "show all x comments" button under "uploaded a screenshot" type activity
+        Page.runInPageContext(() => {
+            const f = window.SteamFacade;
+
+            if (typeof f.global("Blotter_ShowLargeScreenshot") !== "function") {
+
+                f.globalSet("Blotter_ShowLargeScreenshot", (galleryid, showComments) => {
+                    const gallery = f.global("g_BlotterGalleries")[galleryid];
+                    const ss = gallery.shots[gallery.m_screenshotActive];
+                    f.showModalContent(`${ss.m_modalContentLink}&insideModal=1&showComments=${showComments}`, ss.m_modalContentLinkText, ss.m_modalContentLink, true);
+                });
+            }
+        });
+    }
+}

--- a/src/js/Content/Features/Store/App/FPatchHighlightPlayer.js
+++ b/src/js/Content/Features/Store/App/FPatchHighlightPlayer.js
@@ -9,32 +9,15 @@ export default class FPatchHighlightPlayer extends Feature {
         Page.runInPageContext(() => {
             const f = window.SteamFacade;
 
-            // https://github.com/SteamDatabase/SteamTracking/blob/a100fdc357bb6fe4131dc7eb7fa8e17ac4ae10a4/store.steampowered.com/public/javascript/gamehighlightplayer.js#L68
-            if (typeof f.global("SetGameHighlightPlayerVolume") === "function") {
-                f.globalSet("SetGameHighlightPlayerVolume", (flVolume) => {
-                    // Set expiry, which is not done in the original function, making the cookie expire at the session end
-                    const dateExpires = new Date();
-                    dateExpires.setTime(dateExpires.getTime() + (1000 * 60 * 60 * 24 * 365 * 10));
-                    document.cookie = `flGameHighlightPlayerVolume=${flVolume}; expires=${dateExpires.toUTCString()}; path=/`;
-                });
-            }
-
-            // https://github.com/SteamDatabase/SteamTracking/blob/a100fdc357bb6fe4131dc7eb7fa8e17ac4ae10a4/store.steampowered.com/public/javascript/gamehighlightplayer.js#L33
+            /**
+             * Remove the check for `g_bUserSelectedTrailer` to avoid unmuting the player when switching or seeking video
+             * https://github.com/SteamDatabase/SteamTracking/blob/b7e8996a9a2a26296df60b252a608b3dc1c96ab1/store.steampowered.com/public/javascript/gamehighlightplayer.js#L33
+             */
             if (typeof f.global("BIsUserGameHighlightAudioEnabled") === "function") {
+
                 f.globalSet("BIsUserGameHighlightAudioEnabled", () => {
-                    // Do not auto unmute the player when switching or seeking video
                     const rgMatches = document.cookie.match(/(^|; )bGameHighlightAudioEnabled=([^;]*)/);
                     return rgMatches && rgMatches[2] === "true";
-                });
-            }
-
-            // https://github.com/SteamDatabase/SteamTracking/blob/a100fdc357bb6fe4131dc7eb7fa8e17ac4ae10a4/store.steampowered.com/public/javascript/gamehighlightplayer.js#L46
-            if (typeof f.global("SetGameHighlightAudioEnabled") === "function") {
-                f.globalSet("SetGameHighlightAudioEnabled", (bEnabled) => {
-                    // Set expiry, which is not done in the original function, making the cookie expire at the session end
-                    const dateExpires = new Date();
-                    dateExpires.setTime(dateExpires.getTime() + (1000 * 60 * 60 * 24 * 365 * 10));
-                    document.cookie = `bGameHighlightAudioEnabled=${bEnabled ? "true" : "false"}; expires=${dateExpires.toUTCString()}; path=/`;
                 });
             }
         });


### PR DESCRIPTION
Steam finally fixed the volume cookies after over 9 years, according to the date of changes tracked by SteamDB, see https://github.com/SteamDatabase/SteamTracking/commit/b7e8996a9a2a26296df60b252a608b3dc1c96ab1#diff-36b4bfb688a77058a217082422191c34df62ffee5e397812472c0405d6b06732. Unfortunately the issue with unmuting still remains.

Also moved blotter patches to own file so it's easier to locate. I believe we'll need to do this to adopt MV3 anyway.
