### PR TITLE
The ‘Show All’ button for hidden achievements is disabled when it has been clicked

### DIFF
--- a/src/js/Content/Features/Community/ProfileStats/FShowHiddenAchievements.js
+++ b/src/js/Content/Features/Community/ProfileStats/FShowHiddenAchievements.js
@@ -20,6 +20,8 @@ export default class FShowHiddenAchievements extends Feature {
 
         const btn = document.getElementById("as_ach_showall");
         btn.addEventListener("click", async() => {
+            if (btn.classList.contains("btn_disabled"))
+                return;
 
             let achievements = await this.context.getAchievementData();
             achievements = Object.values({...achievements.open}).filter(val => val.hidden);


### PR DESCRIPTION
Fix for the 'Show All' button that keeps adding elements after the button has been disabled.