### PR TITLE
Only check deck compat data for regular apps

### DIFF
--- a/src/js/Content/Features/Store/App/FSteamDeckCompatibility.js
+++ b/src/js/Content/Features/Store/App/FSteamDeckCompatibility.js
@@ -4,7 +4,7 @@ import {Feature, RequestData} from "../../../modulesContent";
 export default class FSteamDeckCompatibility extends Feature {
 
     checkPrerequisites() {
-        return SyncedStorage.get("showdeckcompat");
+        return SyncedStorage.get("showdeckcompat") && !this.context.isDlcLike && !this.context.isVideoOrHardware;
     }
 
     async apply() {


### PR DESCRIPTION
Only regular apps (and software) display this info. I meant to add this back then but forgot to 😅.