### PR TITLE
Fix some issues with add-to-cart-no-redirect

### DIFF
--- a/src/js/Content/Features/Store/App/FDLCCheckboxes.js
+++ b/src/js/Content/Features/Store/App/FDLCCheckboxes.js
@@ -71,7 +71,7 @@ export default class FDLCCheckboxes extends Feature {
 
         const cartForm = document.createElement("form");
         cartForm.name = "add_selected_dlc_to_cart";
-        cartForm.action = "/cart/";
+        cartForm.action = "https://store.steampowered.com/cart/";
         cartForm.method = "POST";
 
         const cartBtn = dlcSection.querySelector("#es_selected_btn");

--- a/src/js/Content/Features/Store/App/FDLCCheckboxes.js
+++ b/src/js/Content/Features/Store/App/FDLCCheckboxes.js
@@ -41,7 +41,7 @@ export default class FDLCCheckboxes extends Feature {
             }
 
             label.append(checkbox);
-            dlcRow.insertAdjacentElement("beforebegin", label);
+            dlcRow.before(label);
         }
 
         // Toggle dsinfo on label when adding/removing wishlist via ds_options dropdown
@@ -75,7 +75,7 @@ export default class FDLCCheckboxes extends Feature {
         cartForm.method = "POST";
 
         const cartBtn = dlcSection.querySelector("#es_selected_btn");
-        cartBtn.insertAdjacentElement("beforebegin", cartForm);
+        cartBtn.before(cartForm);
         cartBtn.addEventListener("click", () => {
             if (!SyncedStorage.has("addtocart_no_redirect") || SyncedStorage.get("addtocart_no_redirect")) {
                 AddToCart.post(cartForm);
@@ -129,8 +129,7 @@ export default class FDLCCheckboxes extends Feature {
 
         dlcSection.addEventListener("change", () => {
 
-            cartForm.innerHTML = "";
-            cartForm.append(inputAction, inputSessionId);
+            cartForm.replaceChildren(inputAction, inputSessionId);
 
             let total = 0;
             for (const node of dlcSection.querySelectorAll(".es_dlc_label > input:checked")) {

--- a/src/js/Content/Features/Store/App/FDLCCheckboxes.js
+++ b/src/js/Content/Features/Store/App/FDLCCheckboxes.js
@@ -1,4 +1,4 @@
-import {HTML, Localization, SyncedStorage} from "../../../../modulesCore";
+import {HTML, Localization} from "../../../../modulesCore";
 import {Feature, Price, User} from "../../../modulesContent";
 import {AddToCart} from "../Common/AddToCart";
 
@@ -76,8 +76,8 @@ export default class FDLCCheckboxes extends Feature {
 
         const cartBtn = dlcSection.querySelector("#es_selected_btn");
         cartBtn.before(cartForm);
-        cartBtn.addEventListener("click", () => {
-            if (!SyncedStorage.has("addtocart_no_redirect") || SyncedStorage.get("addtocart_no_redirect")) {
+        cartBtn.addEventListener("click", async() => {
+            if (await AddToCart.checkFeatureHint()) {
                 AddToCart.post(cartForm);
             } else {
                 cartForm.submit();

--- a/src/js/Content/Features/Store/Common/AddToCart.js
+++ b/src/js/Content/Features/Store/Common/AddToCart.js
@@ -1,5 +1,5 @@
-import {Localization, SyncedStorage} from "../../../../modulesCore";
-import {ConfirmDialog, RequestData} from "../../../modulesContent";
+import {Localization} from "../../../../modulesCore";
+import {RequestData} from "../../../modulesContent";
 import {Page} from "../../Page";
 
 export class AddToCart {
@@ -7,7 +7,6 @@ export class AddToCart {
     static async post(formEl, onWishlist, addToCartEl) {
 
         const cartUrl = formEl.getAttribute("action");
-        const addToCartStr = Localization.str.addtocart_dialog;
         let response;
 
         try {
@@ -19,7 +18,7 @@ export class AddToCart {
             },
             [
                 Localization.str.error,
-                addToCartStr.error_desc,
+                Localization.str.addtocart_dialog.error_desc,
                 err.toString()
             ]);
 
@@ -29,28 +28,6 @@ export class AddToCart {
         // If redirected to a page other than the cart, follow the redirect
         if (response.url !== cartUrl) {
             window.location.assign(response.url);
-            return;
-        }
-
-        let enabled = SyncedStorage.get("addtocart_no_redirect");
-
-        // Show feature hint to first time users
-        if (!SyncedStorage.has("addtocart_no_redirect")) {
-
-            enabled = await ConfirmDialog.openFeatureHint(
-                "addtocart_no_redirect",
-                addToCartStr.title,
-                addToCartStr.desc,
-                addToCartStr.continue,
-                addToCartStr.checkout
-            ) === "OK";
-
-            SyncedStorage.set("addtocart_no_redirect", enabled);
-        }
-
-        // If the dialog is closed or canceled, don't enable feature
-        if (!enabled) {
-            window.location.assign(cartUrl);
             return;
         }
 

--- a/src/js/Content/Features/Store/Common/AddToCart.js
+++ b/src/js/Content/Features/Store/Common/AddToCart.js
@@ -1,8 +1,30 @@
-import {Localization} from "../../../../modulesCore";
-import {RequestData} from "../../../modulesContent";
+import {Localization, SyncedStorage} from "../../../../modulesCore";
+import {ConfirmDialog, RequestData} from "../../../modulesContent";
 import {Page} from "../../Page";
 
 export class AddToCart {
+
+    static async checkFeatureHint() {
+        let enabled = SyncedStorage.get("addtocart_no_redirect");
+
+        // Show feature hint to first time users
+        if (!SyncedStorage.has("addtocart_no_redirect")) {
+            const addToCartStr = Localization.str.addtocart_dialog;
+
+            // If the dialog is closed or canceled, don't enable feature
+            enabled = await ConfirmDialog.openFeatureHint(
+                "addtocart_no_redirect",
+                addToCartStr.title,
+                addToCartStr.desc,
+                addToCartStr.continue,
+                addToCartStr.checkout
+            ) === "OK";
+
+            SyncedStorage.set("addtocart_no_redirect", enabled);
+        }
+
+        return enabled;
+    }
 
     static async post(formEl, onWishlist, addToCartEl) {
 

--- a/src/js/Content/Features/Store/Common/FAddToCartNoRedirect.js
+++ b/src/js/Content/Features/Store/Common/FAddToCartNoRedirect.js
@@ -1,5 +1,5 @@
-import {Localization, SyncedStorage} from "../../../../modulesCore";
-import {ConfirmDialog, ContextType, Feature} from "../../../modulesContent";
+import {SyncedStorage} from "../../../../modulesCore";
+import {ContextType, Feature} from "../../../modulesContent";
 import {AddToCart} from "./AddToCart";
 
 export default class FAddToCartNoRedirect extends Feature {
@@ -62,25 +62,7 @@ export default class FAddToCartNoRedirect extends Feature {
             const form = getFormEl(node.href);
             if (!form) { return; }
 
-            let enabled = SyncedStorage.get("addtocart_no_redirect");
-
-            // Show feature hint to first time users
-            if (!SyncedStorage.has("addtocart_no_redirect")) {
-                const addToCartStr = Localization.str.addtocart_dialog;
-
-                enabled = await ConfirmDialog.openFeatureHint(
-                    "addtocart_no_redirect",
-                    addToCartStr.title,
-                    addToCartStr.desc,
-                    addToCartStr.continue,
-                    addToCartStr.checkout
-                ) === "OK";
-
-                SyncedStorage.set("addtocart_no_redirect", enabled);
-            }
-
-            // If the dialog is closed or canceled, don't enable feature
-            if (!enabled) { return; }
+            if (!await AddToCart.checkFeatureHint()) { return; }
 
             e.preventDefault();
 

--- a/src/js/Content/Features/Store/Common/FAddToCartNoRedirect.js
+++ b/src/js/Content/Features/Store/Common/FAddToCartNoRedirect.js
@@ -15,18 +15,21 @@ export default class FAddToCartNoRedirect extends Feature {
 
         function getFormEl(href) {
 
+            const matches = href.match(/^javascript:([^(]+)\((.+)?\)/);
+            if (matches === null) { return null; }
+
+            const arg = (matches[2] ?? "").trim();
             let formName;
 
-            const fnName = href.match(/javascript:([^(]+)/)[1];
-            switch (fnName) {
+            switch (matches[1]) {
                 case "addToCart":
-                    formName = `add_to_cart_${href.match(/\d+/)[0]}`;
+                    formName = `add_to_cart_${arg}`;
                     break;
                 case "addBundleToCart":
-                    formName = `add_bundle_to_cart_${href.match(/\d+/)[0]}`;
+                    formName = `add_bundle_to_cart_${arg}`;
                     break;
                 case "GamePurchaseDropdownAddToCart":
-                    formName = `add_to_cart_${href.split("'")[1]}`;
+                    formName = `add_to_cart_${arg.slice(1, -1)}`;
                     break;
                 case "addAllDlcToCart":
                     formName = "add_all_dlc_to_cart";
@@ -40,7 +43,7 @@ export default class FAddToCartNoRedirect extends Feature {
             // Special handling for bundles on wishlist
             if (onWishlist && !formEl && fnName === "addBundleToCart") {
                 // Use the actual (wrong) name to locate the associated form
-                formEl = document.forms[`add_to_cart_${href.match(/\d+/)[0]}`];
+                formEl = document.forms[`add_to_cart_${arg}`];
                 // Find the `input` element with the name `subid` and change it to `bundleid`
                 const inputEl = formEl?.elements.subid;
                 if (inputEl) {

--- a/src/js/Content/Features/Store/Common/FAddToCartNoRedirect.js
+++ b/src/js/Content/Features/Store/Common/FAddToCartNoRedirect.js
@@ -1,5 +1,5 @@
-import {SyncedStorage} from "../../../../modulesCore";
-import {ContextType, Feature} from "../../../modulesContent";
+import {Localization, SyncedStorage} from "../../../../modulesCore";
+import {ConfirmDialog, ContextType, Feature} from "../../../modulesContent";
 import {AddToCart} from "./AddToCart";
 
 export default class FAddToCartNoRedirect extends Feature {
@@ -51,13 +51,33 @@ export default class FAddToCartNoRedirect extends Feature {
             return formEl;
         }
 
-        function handler(e) {
+        async function handler(e) {
 
             const node = e.target.closest("a[href^=javascript]");
             if (!node) { return; }
 
             const form = getFormEl(node.href);
             if (!form) { return; }
+
+            let enabled = SyncedStorage.get("addtocart_no_redirect");
+
+            // Show feature hint to first time users
+            if (!SyncedStorage.has("addtocart_no_redirect")) {
+                const addToCartStr = Localization.str.addtocart_dialog;
+
+                enabled = await ConfirmDialog.openFeatureHint(
+                    "addtocart_no_redirect",
+                    addToCartStr.title,
+                    addToCartStr.desc,
+                    addToCartStr.continue,
+                    addToCartStr.checkout
+                ) === "OK";
+
+                SyncedStorage.set("addtocart_no_redirect", enabled);
+            }
+
+            // If the dialog is closed or canceled, don't enable feature
+            if (!enabled) { return; }
 
             e.preventDefault();
 

--- a/src/js/Content/Features/Store/Common/FAddToCartNoRedirect.js
+++ b/src/js/Content/Features/Store/Common/FAddToCartNoRedirect.js
@@ -87,7 +87,8 @@ export default class FAddToCartNoRedirect extends Feature {
         if (onWishlist) {
             document.addEventListener("click", handler);
         } else {
-            for (const node of document.querySelectorAll(".btn_addtocart > a[href^=javascript]")) {
+            // Avoid selecting the purchase option node, e.g. on GTA5, EVE Online
+            for (const node of document.querySelectorAll(".btn_addtocart:not([id$='select_option']) > a[href^=javascript]")) {
                 node.addEventListener("click", handler);
             }
         }


### PR DESCRIPTION
As a follow-up, I'm planning to move handling free promotions to it's own method (similar to how Steam handles the Add to Library option), but that'll have to wait until Steam fixes their own stuff.