### PR TITLE
FKeepEditableRanking: select all text when focusing input field

### DIFF
--- a/src/js/Content/Features/Store/Wishlist/FKeepEditableRanking.js
+++ b/src/js/Content/Features/Store/Wishlist/FKeepEditableRanking.js
@@ -60,6 +60,11 @@ export default class FKeepEditableRanking extends CallbackFeature {
                 input.value = newInput.value;
                 input.dispatchEvent(new Event("change"));
             });
+
+            // Select all text when focusing input field
+            newInput.addEventListener("focus", () => {
+                newInput.select();
+            });
         }
     }
 }


### PR DESCRIPTION
A simple QoL improvement and mimics Steam's behaviour.