### PR TITLE
FReviewSort: remove update review background action

### DIFF
--- a/src/js/Background/Modules/IndexedDB.js
+++ b/src/js/Background/Modules/IndexedDB.js
@@ -352,13 +352,8 @@ class IndexedDB {
         if (!IndexedDB.timestampedStores.has(storeName)) { return null; }
 
         const expiry = await IndexedDB.db.get("expiries", storeName);
-        let expired = true;
 
-        if (expiry) {
-            expired = IndexedDB.isExpired(expiry);
-        }
-
-        if (expired) {
+        if (!expiry || IndexedDB.isExpired(expiry)) {
             await IndexedDB.clear(storeName);
             if (!options.preventFetch) {
                 return IndexedDB.fetchUpdatedData(storeName, null, options.params);

--- a/src/js/Background/Modules/SteamCommunityApi.js
+++ b/src/js/Background/Modules/SteamCommunityApi.js
@@ -250,7 +250,9 @@ class SteamCommunityApi extends Api {
                 // Count total awards received
                 const awards = Array.from(node.querySelectorAll(".review_award"))
                     .reduce((acc, node) => {
-                        const count = node.classList.contains("more_btn") ? 0 : Number(node.querySelector(".review_award_count").textContent.trim());
+                        const count = node.classList.contains("more_btn") 
+                            ? 0 
+                            : Number(node.querySelector(".review_award_count").textContent.trim());
                         return acc + count;
                     }, 0);
 

--- a/src/js/Background/Modules/SteamCommunityApi.js
+++ b/src/js/Background/Modules/SteamCommunityApi.js
@@ -211,13 +211,12 @@ class SteamCommunityApi extends Api {
         return IndexedDB.get("workshopFileSizes", id, {preventFetch});
     }
 
-    static async fetchReviews({"key": steamId, "params": {reviewCount}}) {
+    static async fetchReviews({"key": steamId, "params": {pages}}) {
         const parser = new DOMParser();
-        const pageCount = 10;
         const reviews = [];
         let defaultOrder = 0;
 
-        for (let p = 1; p <= Math.ceil(reviewCount / pageCount); p++) {
+        for (let p = 1; p <= pages; p++) {
             const doc = parser.parseFromString(await SteamCommunityApi.getPage(`${steamId}/recommended`, {p}), "text/html");
 
             for (const node of doc.querySelectorAll(".review_box")) {
@@ -277,8 +276,8 @@ class SteamCommunityApi extends Api {
         return IndexedDB.put("reviews", {[steamId]: reviews});
     }
 
-    static getReviews(steamId, reviewCount) {
-        return IndexedDB.get("reviews", steamId, {"params": {reviewCount}});
+    static getReviews(steamId, pages) {
+        return IndexedDB.get("reviews", steamId, {"params": {pages}});
     }
 
     /*

--- a/src/js/Background/background.js
+++ b/src/js/Background/background.js
@@ -86,7 +86,6 @@ const actionCallbacks = new Map([
     ["clearownprofile", SteamCommunityApi.clearOwn],
     ["workshopfilesize", SteamCommunityApi.getWorkshopFileSize],
     ["reviews", SteamCommunityApi.getReviews],
-    ["updatereviewnode", SteamCommunityApi.updateReviewNode],
 
     ["itad.authorize", ITADApi.authorize],
     ["itad.disconnect", ITADApi.disconnect],

--- a/src/js/Content/Features/Community/Recommended/FReviewSort.js
+++ b/src/js/Content/Features/Community/Recommended/FReviewSort.js
@@ -1,5 +1,5 @@
 import {HTML, Localization, SyncedStorage, TimeUtils} from "../../../../modulesCore";
-import {Background, Feature, Messenger, Sortbox, User} from "../../../modulesContent";
+import {Background, Feature, Sortbox, User} from "../../../modulesContent";
 import {Page} from "../../Page";
 
 export default class FReviewSort extends Feature {
@@ -21,24 +21,6 @@ export default class FReviewSort extends Feature {
 
         // Max reviews displayed per page. Used for fetching reviews and synced with background script.
         this._pageCount = 10;
-
-        Messenger.addMessageListener("updateReview", id => {
-            Background.action("updatereviewnode", this._path, document.querySelector(`[id$="${id}"`).closest(".review_box").outerHTML, this._reviewCount)
-                .then(() => { this._getReviews(); });
-        });
-
-        Page.runInPageContext(() => {
-            window.SteamFacade.jq(document).ajaxSuccess((event, xhr, {url}) => {
-                const pathname = new URL(url).pathname;
-                if (pathname.startsWith("/userreviews/rate/")
-                    || pathname.startsWith("/userreviews/votetag/")
-                    || pathname.startsWith("/userreviews/update/")) {
-
-                    const id = pathname.split("/").pop();
-                    window.Messenger.postMessage("updateReview", id);
-                }
-            });
-        });
 
         document.querySelector("#leftContents > h1").before(Sortbox.get(
             "reviews",

--- a/src/js/Content/Features/Community/Recommended/FReviewSort.js
+++ b/src/js/Content/Features/Community/Recommended/FReviewSort.js
@@ -19,8 +19,11 @@ export default class FReviewSort extends Feature {
         // Current page. Used to calculate the portion of reviews to show after sorting.
         this._curPage = new URLSearchParams(window.location.search).get("p") || 1;
 
-        // Max reviews displayed per page. Used for fetching reviews and synced with background script.
+        // Max reviews displayed per page.
         this._pageCount = 10;
+
+        // Number of pages. Passed to background script for fetching reviews.
+        this._pages = Math.ceil(this._reviewCount / this._pageCount);
 
         document.querySelector("#leftContents > h1").before(Sortbox.get(
             "reviews",
@@ -148,7 +151,7 @@ export default class FReviewSort extends Feature {
         }, [Localization.str.processing, Localization.str.wait]);
 
         try {
-            this._reviews = await Background.action("reviews", this._path, this._reviewCount);
+            this._reviews = await Background.action("reviews", this._path, this._pages);
         } finally {
 
             // Delay half a second to avoid dialog flicker when grabbing cache


### PR DESCRIPTION
This just removes the update review action since the whole idea is flawed. Supersedes #1641.

Some things left to consider:
1. Add a "force fetch" button if there's demand.
2. Add progress info the waiting dialog (and a way to abort the whole thing). That goes for all features that might fetch a lot of pages though.