### PR TITLE
Add discount percentage filter on search page

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -3013,7 +3013,8 @@ label.es_dlc_label > input:checked::after {
 .search_results.mixed .as-hide-mixed,
 .search_results.negative .as-hide-negative,
 .search_results.reviews-score .as-reviews-score,
-.search_results .as-reviews-count {
+.search_results .as-reviews-count,
+.search_results .as-discount-percent {
   height: 0;
   margin: 0;
   border: none;
@@ -3039,11 +3040,11 @@ label.es_dlc_label > input:checked::after {
   padding: 7.5px 8px !important; /* 7.5px is the (line-height (28px) - font-size (13px)) / 2 */
 }
 
-.as-reviews-count-filter {
+.as-reviews-count-filter, .as-discount-percent-filter {
   margin-top: 10px;
 }
 
-.as-reviews-count-filter__header {
+.as-reviews-count-filter__header, .as-discount-percent-filter__header {
   margin-left: 8px;
   font-size: 13px;
   font-family: "Motiva Sans", Sans-serif;
@@ -3051,7 +3052,7 @@ label.es_dlc_label > input:checked::after {
   color: #9fbbcb;
 }
 
-.as-reviews-count-filter__content {
+.as-reviews-count-filter__content, .as-discount-percent-filter__content {
   display: flex;
   align-items: center;
   padding: 0 12px;
@@ -3059,7 +3060,7 @@ label.es_dlc_label > input:checked::after {
 }
 
 /* https://github.com/SteamDatabase/SteamTracking/blob/ad1bfe7966cbfc3a8cdff7d0fcc9f3437425b7a8/store.steampowered.com/public/css/v6/search.css#L546 */
-.as-reviews-count-filter__input {
+.as-reviews-count-filter__input, .as-discount-percent-filter__input  {
   min-width: 0;
   background-color: rgba( 0, 0, 0, 0.2 );
   color: #fff;

--- a/src/js/Content/Features/Store/Search/FSearchFilters.js
+++ b/src/js/Content/Features/Store/Search/FSearchFilters.js
@@ -9,6 +9,7 @@ import {MixedSearchFilter} from "./Filters/MixedSearchFilter";
 import {NegativeSearchFilter} from "./Filters/NegativeSearchFilter";
 import {ReviewsCountSearchFilter} from "./Filters/ReviewsCountSearchFilter";
 import {ReviewsScoreSearchFilter} from "./Filters/ReviewsScoreSearchFilter";
+import {DiscountPercentSearchFilter} from "./Filters/DiscountPercentSearchFilter";
 
 export default class FSearchFilters extends Feature {
 
@@ -21,6 +22,7 @@ export default class FSearchFilters extends Feature {
             NegativeSearchFilter,
             ReviewsScoreSearchFilter,
             ReviewsCountSearchFilter,
+            DiscountPercentSearchFilter
         ].map(Filter => new Filter(this));
 
         this._urlParams = {};

--- a/src/js/Content/Features/Store/Search/Filters/DiscountPercentSearchFilter.js
+++ b/src/js/Content/Features/Store/Search/Filters/DiscountPercentSearchFilter.js
@@ -98,12 +98,12 @@ export class DiscountPercentSearchFilter extends SearchFilter {
     _addRowMetadata(rows = document.querySelectorAll(".search_result_row:not([data-as-discount-percent])")) {
 
         for (const row of rows) {
-            const discountPercent = this.getDiscountPercent(row);
+            const discountPercent = this._getDiscountPercent(row);
             row.dataset.asDiscountPercent = discountPercent;
         }
     }
 
-    getDiscountPercent(row) {
+    _getDiscountPercent(row) {
         let discount = 0;
         const discountEl = row.querySelector(".search_discount");
         

--- a/src/js/Content/Features/Store/Search/Filters/DiscountPercentSearchFilter.js
+++ b/src/js/Content/Features/Store/Search/Filters/DiscountPercentSearchFilter.js
@@ -1,0 +1,133 @@
+import {Localization} from "../../../../../Core/Localization/Localization";
+import {SearchFilter} from "./SearchFilter";
+
+export class DiscountPercentSearchFilter extends SearchFilter {
+
+    constructor(feature) {
+        super("as-discount-percent", feature);
+
+        this._val = null;
+    }
+
+    get active() {
+        return this._minCount.value || this._maxCount.value;
+    }
+
+    getHTML() {
+
+        return `<div class="as-discount-percent-filter">
+                    <div class="as-discount-percent-filter__header">${Localization.str.search_filters.discount_percent.count}</div>
+                    <div class="as-discount-percent-filter__content js-discount-percent-filter">
+                        <input class="as-discount-percent-filter__input js-discount-percent-input js-discount-percent-lower" type="number" min="0" max="100" step="1" placeholder="${Localization.str.search_filters.discount_percent.min_count}">
+                        -
+                        <input class="as-discount-percent-filter__input js-discount-percent-input js-discount-percent-upper" type="number" min="0" max="100" step="1" placeholder="${Localization.str.search_filters.discount_percent.max_count}">
+                        <input type="hidden" name="as-discount-percent">
+                    </div>
+                </div>`;
+    }
+
+    setup(params) {
+
+        this._minCount = document.querySelector(".js-discount-percent-lower");
+        this._maxCount = document.querySelector(".js-discount-percent-upper");
+
+        for (const input of document.querySelectorAll(".js-discount-percent-input")) {
+
+            input.addEventListener("change", () => {
+                this._apply();
+
+                const minVal = this._minCount.value;
+                const maxVal = this._maxCount.value;
+                let val = null;
+
+                if ((minVal && Number(minVal) !== 0) || maxVal) {
+                    val = `${minVal}-${maxVal}`;
+                }
+
+                this.value = val;
+            });
+
+            input.addEventListener("keydown", e => {
+                if (e.key === "Enter") {
+
+                    // Prevents unnecessary submitting of the advanced search form
+                    e.preventDefault();
+
+                    input.dispatchEvent(new Event("change"));
+                }
+            });
+        }
+
+        super.setup(params);
+    }
+
+    _setState(params) {
+
+        let lowerCountVal = "";
+        let upperCountVal = "";
+
+        if (params.has("as-discount-percent")) {
+
+            const val = params.get("as-discount-percent");
+            const match = val.match(/(^\d*)-(\d*)/);
+
+            this._value = val;
+
+            if (match) {
+                let [, lower, upper] = match;
+                lower = parseInt(lower);
+                upper = parseInt(upper);
+
+                if (!isNaN(lower)) {
+                    lowerCountVal = lower;
+                }
+                if (!isNaN(upper)) {
+                    upperCountVal = upper;
+                }
+            }
+        }
+
+        if (lowerCountVal !== this._minCount.value) {
+            this._minCount.value = lowerCountVal;
+        }
+        if (upperCountVal !== this._maxCount.value) {
+            this._maxCount.value = upperCountVal;
+        }
+    }
+
+    _addRowMetadata(rows = document.querySelectorAll(".search_result_row:not([data-as-discount-percent])")) {
+
+        for (const row of rows) {
+            let discountPercent = this.getDiscountPercent(row);
+            row.dataset.asDiscountPercent = discountPercent;
+        }
+    }
+
+    getDiscountPercent(row) {
+        let discount = 0;
+        const discountEl = row.querySelector('.search_discount');
+        
+        if (!discountEl || discountEl.innerText === "") {
+            return 0
+        }
+
+        let temp = discountEl.innerText.replace("-","").replace("%","");
+        discount = parseInt(temp);
+        if (isNaN(discount)) {
+        discount = 0
+        }
+        
+        return discount;
+    }
+
+    _apply(rows = document.querySelectorAll(".search_result_row")) {
+
+        const minDiscount = this._minCount.value === "" ? 0 : Number(this._minCount.value);
+        const maxDiscount = this._maxCount.value === "" ? Infinity : Number(this._maxCount.value);
+
+        for (const row of rows) {
+            const rowDiscount = Number(row.dataset.asDiscountPercent);
+            row.classList.toggle("as-discount-percent", rowDiscount < minDiscount || rowDiscount > maxDiscount);
+        }
+    }
+}

--- a/src/js/Content/Features/Store/Search/Filters/DiscountPercentSearchFilter.js
+++ b/src/js/Content/Features/Store/Search/Filters/DiscountPercentSearchFilter.js
@@ -98,23 +98,23 @@ export class DiscountPercentSearchFilter extends SearchFilter {
     _addRowMetadata(rows = document.querySelectorAll(".search_result_row:not([data-as-discount-percent])")) {
 
         for (const row of rows) {
-            let discountPercent = this.getDiscountPercent(row);
+            const discountPercent = this.getDiscountPercent(row);
             row.dataset.asDiscountPercent = discountPercent;
         }
     }
 
     getDiscountPercent(row) {
         let discount = 0;
-        const discountEl = row.querySelector('.search_discount');
+        const discountEl = row.querySelector(".search_discount");
         
         if (!discountEl || discountEl.innerText === "") {
-            return 0
+            return 0;
         }
 
-        let temp = discountEl.innerText.replace("-","").replace("%","");
-        discount = parseInt(temp);
+        const discountText = discountEl.innerText.replace("-", "").replace("%", "");
+        discount = parseInt(discountText);
         if (isNaN(discount)) {
-        discount = 0
+            discount = 0;
         }
         
         return discount;

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -230,6 +230,11 @@
             "min_count": "Min count",
             "max_count": "Max count"
         },
+        "discount_percent": {
+            "count": "Discount percent:",
+            "min_count": "Min %",
+            "max_count": "Max %"
+        },
         "hide_cart": "Hide items in your Cart",
         "hide_ea": "Hide Early Access items",
         "hide_mixed": "Hide mixed rating items",


### PR DESCRIPTION
This PR adds a new filter to the Steam search page for filtering the results by the discount percentage. I've used the existing Review Count filter as a template for this. 

Both the minimum and maximum desired percentage can be specified (or left blank individually). Any search results that are not discounted at the moment are treated as having 0% discount.

![as-discount-percentage](https://github.com/IsThereAnyDeal/AugmentedSteam/assets/11618454/c434ae3a-d671-414c-9703-e166a6cc61d0)

Satisfies issue #938 .