### PR TITLE
FKeepSSACheckboxState: check current checkbox state when saving preference

### DIFF
--- a/src/js/Content/Features/Common/FKeepSSACheckboxState.js
+++ b/src/js/Content/Features/Common/FKeepSSACheckboxState.js
@@ -15,7 +15,7 @@ export default class FKeepSSACheckboxState extends Feature {
             node.checked = SyncedStorage.get("keepssachecked");
 
             node.addEventListener("click", () => {
-                SyncedStorage.set("keepssachecked", !SyncedStorage.get("keepssachecked"));
+                SyncedStorage.set("keepssachecked", node.checked);
             });
         }
     }


### PR DESCRIPTION
Save current checkbox state to preference, instead of the invert of current preference. This fixes the case where if you have 2 (or an even number) of tabs open and enable the checkbox on both, the resulting preference will be `false`.