### PR TITLE
Fix clicking items in the new item row not adding features

### DIFF
--- a/src/js/Content/Features/Community/Inventory/CInventory.js
+++ b/src/js/Content/Features/Community/Inventory/CInventory.js
@@ -35,7 +35,7 @@ export class CInventory extends CCommunityBase {
 
         Page.runInPageContext(() => {
             document.addEventListener("click", ({target}) => {
-                if (!target.matches("a.inventory_item_link, a.newitem")) { return; }
+                if (!target.closest("a.inventory_item_link, a.newitem")) { return; }
 
                 const f = window.SteamFacade;
                 const g = f.global;


### PR DESCRIPTION
When clicking items in the new item row, we're actually clicking the children of the selector, so use `.closest` instead.