### PR TITLE
Fix YouTube query for Gameplay and Reviews to make them more relevant

### DIFF
--- a/src/js/Content/Features/Store/Common/FExtraLinks.js
+++ b/src/js/Content/Features/Store/Common/FExtraLinks.js
@@ -161,13 +161,13 @@ export default class FExtraLinks extends Feature {
             },
             {
                 "iconClass": "as_youtube_btn",
-                "link": `https://www.youtube.com/results?search_query=${encodeURIComponent(`${appName} "PC Gameplay"`)}`,
+                "link": `https://www.youtube.com/results?search_query=${encodeURIComponent(`${appName} "PC" Gameplay`)}`,
                 "text": Localization.str.youtube_gameplay,
                 "enabled": isAppPage && appName && SyncedStorage.get("showyoutubegameplay"),
             },
             {
                 "iconClass": "as_youtube_btn",
-                "link": `https://www.youtube.com/results?search_query=${encodeURIComponent(`${appName} "PC" intitle:Review`)}`,
+                "link": `https://www.youtube.com/results?search_query=${encodeURIComponent(`${appName} "PC" Review`)}`,
                 "text": Localization.str.youtube_reviews,
                 "enabled": isAppPage && appName && SyncedStorage.get("showyoutubereviews"),
             },


### PR DESCRIPTION
This change changes the search query to display more relevant YouTube videos by making the search queue less restrictive.

All search queries were tested in incognito mode to prevent personal recommendations. Tested recommendations for an unreleased game (for which there is no PC video yet) and an already released one.

Possibly related to https://github.com/IsThereAnyDeal/AugmentedSteam/issues/707

---

**Gameplay query (game not yet released on Steam)**

Before:
![gameplay-before](https://github.com/IsThereAnyDeal/AugmentedSteam/assets/4838367/4cc3b2cb-9321-4395-b8ea-c4555223fafb)

After:
![gameplay-after](https://github.com/IsThereAnyDeal/AugmentedSteam/assets/4838367/043710b1-40fc-41e5-97e9-d9cc105e5b73)

---

**Review query (game not yet released on Steam)**

Before:
![review-before](https://github.com/IsThereAnyDeal/AugmentedSteam/assets/4838367/ec05ec43-e4ed-426c-8ce6-3b29cd2e8f05)

After:
![review-after](https://github.com/IsThereAnyDeal/AugmentedSteam/assets/4838367/84dd40d5-3515-4582-a447-f6f0453cca59)

The results are now at least relevant to this game.

---

**Gameplay query (game already released on Steam)**

Before:
![sg-gameplay-before](https://github.com/IsThereAnyDeal/AugmentedSteam/assets/4838367/d7f12d56-cfad-4c46-b62d-bb2330204e4d)

After:
![sg-gameplay-after](https://github.com/IsThereAnyDeal/AugmentedSteam/assets/4838367/2ea09c56-c5b0-4976-9abb-170a4d1dffe2)

The results are identical.

---

**Review query (game already released on Steam)**

Before:
![sg-review-before](https://github.com/IsThereAnyDeal/AugmentedSteam/assets/4838367/991fc9bb-5860-4819-98ac-a8208453cecf)

After:
![sg-review-after](https://github.com/IsThereAnyDeal/AugmentedSteam/assets/4838367/810cb691-ea55-463f-97a9-bdd53d3b2afe)

The results are more relevant.