### PR TITLE
Add yearly summary table for licenses page

### DIFF
--- a/config/manifests/base.json
+++ b/config/manifests/base.json
@@ -132,7 +132,7 @@
         "*://*.steampowered.com/steamaccount/addfunds",
         "*://*.steampowered.com/digitalgiftcards/selectgiftcard",
         "*://*.steampowered.com/account",
-        "*://*.steampowered.com/account/licenses",
+        "*://*.steampowered.com/account/licenses[/*]",
         "*://*.steampowered.com/account/registerkey",
         "*://*.steampowered.com/bundle/*",
         "*://*.steampowered.com/sub/*",

--- a/config/manifests/base.json
+++ b/config/manifests/base.json
@@ -78,7 +78,7 @@
       "js": "js/store/account.js"
     },
     {
-      "matches": "*://store.steampowered.com/account/licenses/",
+      "matches": "*://store.steampowered.com/account/licenses[/*]",
       "js": "js/store/licences.js"
     },
     {
@@ -132,7 +132,7 @@
         "*://*.steampowered.com/steamaccount/addfunds",
         "*://*.steampowered.com/digitalgiftcards/selectgiftcard",
         "*://*.steampowered.com/account",
-        "*://*.steampowered.com/account/licenses/",
+        "*://*.steampowered.com/account/licenses",
         "*://*.steampowered.com/account/registerkey",
         "*://*.steampowered.com/bundle/*",
         "*://*.steampowered.com/sub/*",

--- a/config/manifests/base.json
+++ b/config/manifests/base.json
@@ -78,6 +78,10 @@
       "js": "js/store/account.js"
     },
     {
+      "matches": "*://store.steampowered.com/account/licenses/",
+      "js": "js/store/licences.js"
+    },
+    {
       "matches": "*://*.steampowered.com/account/registerkey",
       "js": "js/store/registerkey.js"
     },
@@ -128,6 +132,7 @@
         "*://*.steampowered.com/steamaccount/addfunds",
         "*://*.steampowered.com/digitalgiftcards/selectgiftcard",
         "*://*.steampowered.com/account",
+        "*://*.steampowered.com/account/licenses/",
         "*://*.steampowered.com/account/registerkey",
         "*://*.steampowered.com/bundle/*",
         "*://*.steampowered.com/sub/*",

--- a/config/webpack/webpack.common.cjs
+++ b/config/webpack/webpack.common.cjs
@@ -45,6 +45,7 @@ module.exports = {
         "js/community/workshop": "./src/js/Content/Features/Community/Workshop/PWorkshop.js",
         "js/community/workshop_browse": "./src/js/Content/Features/Community/WorkshopBrowse/PWorkshopBrowse.js",
         "js/store/account": "./src/js/Content/Features/Store/Account/PAccount.js",
+        "js/store/licences": "./src/js/Content/Features/Store/Licenses/PLicenses.js",
         "js/store/agecheck": "./src/js/Content/Features/Store/AgeCheck/PAgecheck.js",
         "js/store/app": "./src/js/Content/Features/Store/App/PApp.js",
         "js/store/bundle": "./src/js/Content/Features/Store/Bundle/PBundle.js",

--- a/src/js/Content/Features/Store/Licenses/CLicenses.js
+++ b/src/js/Content/Features/Store/Licenses/CLicenses.js
@@ -1,0 +1,12 @@
+import {Context, ContextType} from "../../../modulesContent";
+import FLincensesSummary from "./FLincensesSummary";
+
+export class CLicenses extends Context {
+
+    constructor() {
+
+        super(ContextType.ACCOUNT, [
+            FLincensesSummary,
+        ]);
+    }
+}

--- a/src/js/Content/Features/Store/Licenses/FLincensesSummary.js
+++ b/src/js/Content/Features/Store/Licenses/FLincensesSummary.js
@@ -9,7 +9,11 @@ export default class FLincensesSummary extends Feature {
         const list = {};
         const types = {};
         for ( const item of all ) {
-            const year = item.querySelector( ".license_date_col" ).innerHTML.split( " " )[2];
+            const date_str = item.querySelector( ".license_date_col" ).innerHTML;
+            const year =
+                   /\d{4}$/.exec(date_str)?.[0] // "24 May, 2022" -> "2022"
+                || /^\d{4}/.exec(date_str)?.[0] // "2023. aug. 2." -> "2023"
+                || "";
             const typ = item.querySelector( ".license_acquisition_col" ).innerHTML.trim();
             (list[year] ||= {})[typ] = (list[year][typ] || 0) + 1;
             types[typ] = (types[typ] || 0) + 1;

--- a/src/js/Content/Features/Store/Licenses/FLincensesSummary.js
+++ b/src/js/Content/Features/Store/Licenses/FLincensesSummary.js
@@ -51,19 +51,23 @@ export default class FLincensesSummary extends Feature {
             `<div class="block" style="margin-bottom: 20px">
                 <div class="block_content">
                     <table class="account_table">
-                        <tbody>
+                        <thead>
                             <tr>
                                 <th>${Localization.str.year}</th>
                                 ${tableHeader}
                                 <th>${Localization.str.all}</th>
                             </tr>
+                        </thead>
+                        <tbody>
                             ${rows}
+                        </tbody>
+                        <tfoot>
                             <tr>
                                 <td>${Localization.str.all}</td>
                                 ${tableFooter}
                                 <td>${totalGlobal}</td>
                             </tr>
-                        </tbody>
+                        </tfoot>
                     </table>
                 </div>
             </div>`

--- a/src/js/Content/Features/Store/Licenses/FLincensesSummary.js
+++ b/src/js/Content/Features/Store/Licenses/FLincensesSummary.js
@@ -1,0 +1,68 @@
+import {HTML, Localization} from "../../../../modulesCore";
+import {Feature} from "../../../modulesContent";
+
+export default class FLincensesSummary extends Feature {
+
+    apply() {
+
+        const all = document.querySelectorAll(".account_table tbody tr[data-panel]");
+        const list = {};
+        const types = {};
+        for ( const item of all ) {
+            const year = item.querySelector( ".license_date_col" ).innerHTML.split( " " )[2];
+            const typ = item.querySelector( ".license_acquisition_col" ).innerHTML.trim();
+            (list[year] ||= {})[typ] = (list[year][typ] || 0) + 1;
+            types[typ] = (types[typ] || 0) + 1;
+        }
+
+        const list_entries = Object.entries(list).reverse()
+        const totals = [];
+        list_entries.forEach(([,row], i, arr) => {
+            totals[i] = Object.entries(row)
+                .map(([,count]) => count)
+                .reduce((a,b) => a+b, 0);
+        })
+        const total_global = totals.reduce((a,b) => a+b, 0);
+
+        const types_entries = Object.entries(types);
+
+        HTML.beforeBegin(
+            document.querySelector('.youraccount_page > .block'),
+            `<div class="block" style="margin-bottom: 20px">
+                <div class="block_content">
+                    <table class="account_table">
+                        <tbody>
+                            <tr>
+                                <th>${Localization.str.year}</th>
+                                ${types_entries
+                                    .map(([name]) => `<th>${name}</th>` )
+                                    .join('')
+                                }
+                                <th>${Localization.str.all}</th>
+                            </tr>
+                            ${list_entries
+                                .map(([year, row], i) =>
+                            `<tr>
+                                <td>${year}</td>
+                                ${types_entries
+                                    .map(([name]) => `<td>${row[name] || '0'}</td>`)
+                                    .join('')
+                                }
+                                <td>${totals[i] || '0'}</td>
+                            </tr>`)
+                                .join('')}
+                            <tr>
+                                <td>${Localization.str.all}</td>
+                                ${types_entries
+                                    .map(([,value]) => `<td>${value || '0'}</td>`)
+                                    .join('')
+                                }
+                                <td>${total_global}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>`
+        );
+    }
+}

--- a/src/js/Content/Features/Store/Licenses/FLincensesSummary.js
+++ b/src/js/Content/Features/Store/Licenses/FLincensesSummary.js
@@ -8,60 +8,59 @@ export default class FLincensesSummary extends Feature {
         const all = document.querySelectorAll(".account_table tbody tr[data-panel]");
         const list = {};
         const types = {};
-        for ( const item of all ) {
-            const date_str = item.querySelector( ".license_date_col" ).innerHTML;
-            const year =
-                   /\d{4}$/.exec(date_str)?.[0] // "24 May, 2022" -> "2022"
-                || /^\d{4}/.exec(date_str)?.[0] // "2023. aug. 2." -> "2023"
+        for (const item of all) {
+            const dateStr = item.querySelector(".license_date_col").innerHTML;
+            const year
+                   = /\d{4}$/.exec(dateStr)?.[0] // "24 May, 2022" -> "2022"
+                || /^\d{4}/.exec(dateStr)?.[0] // "2023. aug. 2." -> "2023"
                 || "";
-            const typ = item.querySelector( ".license_acquisition_col" ).innerHTML.trim();
+            const typ = item.querySelector(".license_acquisition_col").innerHTML.trim();
             (list[year] ||= {})[typ] = (list[year][typ] || 0) + 1;
             types[typ] = (types[typ] || 0) + 1;
         }
 
-        const list_entries = Object.entries(list).reverse()
+        const listEntries = Object.entries(list).reverse();
         const totals = [];
-        list_entries.forEach(([,row], i, arr) => {
+        listEntries.forEach(([, row], i, arr) => {
             totals[i] = Object.entries(row)
-                .map(([,count]) => count)
-                .reduce((a,b) => a+b, 0);
-        })
-        const total_global = totals.reduce((a,b) => a+b, 0);
+                .map(([, count]) => count)
+                .reduce((a, b) => a + b, 0);
+        });
+        const totalGlobal = totals.reduce((a, b) => a + b, 0);
 
-        const types_entries = Object.entries(types);
+        const typesEntries = Object.entries(types);
 
         HTML.beforeBegin(
-            document.querySelector('.youraccount_page > .block'),
+            document.querySelector(".youraccount_page > .block"),
             `<div class="block" style="margin-bottom: 20px">
                 <div class="block_content">
                     <table class="account_table">
                         <tbody>
                             <tr>
                                 <th>${Localization.str.year}</th>
-                                ${types_entries
-                                    .map(([name]) => `<th>${name}</th>` )
-                                    .join('')
-                                }
+                                ${typesEntries
+        .map(([name]) => `<th>${name}</th>`)
+        .join("")
+}
                                 <th>${Localization.str.all}</th>
                             </tr>
-                            ${list_entries
-                                .map(([year, row], i) =>
-                            `<tr>
+                            ${listEntries
+        .map(([year, row], i) => `<tr>
                                 <td>${year}</td>
-                                ${types_entries
-                                    .map(([name]) => `<td>${row[name] || '0'}</td>`)
-                                    .join('')
-                                }
-                                <td>${totals[i] || '0'}</td>
+                                ${typesEntries
+        .map(([name]) => `<td>${row[name] || "0"}</td>`)
+        .join("")
+}
+                                <td>${totals[i] || "0"}</td>
                             </tr>`)
-                                .join('')}
+        .join("")}
                             <tr>
                                 <td>${Localization.str.all}</td>
-                                ${types_entries
-                                    .map(([,value]) => `<td>${value || '0'}</td>`)
-                                    .join('')
-                                }
-                                <td>${total_global}</td>
+                                ${typesEntries
+        .map(([, value]) => `<td>${value || "0"}</td>`)
+        .join("")
+}
+                                <td>${totalGlobal}</td>
                             </tr>
                         </tbody>
                     </table>

--- a/src/js/Content/Features/Store/Licenses/FLincensesSummary.js
+++ b/src/js/Content/Features/Store/Licenses/FLincensesSummary.js
@@ -4,31 +4,47 @@ import {Feature} from "../../../modulesContent";
 export default class FLincensesSummary extends Feature {
 
     apply() {
-
-        const all = document.querySelectorAll(".account_table tbody tr[data-panel]");
+        const all = document.querySelectorAll(".account_table tr[data-panel]");
         const list = {};
         const types = {};
+
         for (const item of all) {
             const dateStr = item.querySelector(".license_date_col").innerHTML;
-            const year
-                   = /\d{4}$/.exec(dateStr)?.[0] // "24 May, 2022" -> "2022"
-                || /^\d{4}/.exec(dateStr)?.[0] // "2023. aug. 2." -> "2023"
-                || "";
+            const year = /\d{4}/.exec(dateStr)?.[0] ?? "";
             const typ = item.querySelector(".license_acquisition_col").innerHTML.trim();
-            (list[year] ||= {})[typ] = (list[year][typ] || 0) + 1;
-            types[typ] = (types[typ] || 0) + 1;
+
+            (list[year] ??= {})[typ] = (list[year][typ] ?? 0) + 1;
+            types[typ] = (types[typ] ?? 0) + 1;
         }
 
         const listEntries = Object.entries(list).reverse();
-        const totals = [];
-        listEntries.forEach(([, row], i, arr) => {
-            totals[i] = Object.entries(row)
+        const totals = listEntries.map(
+            ([, row]) => Object.entries(row)
                 .map(([, count]) => count)
-                .reduce((a, b) => a + b, 0);
-        });
-        const totalGlobal = totals.reduce((a, b) => a + b, 0);
+                .reduce((a, b) => a + b, 0)
+        );
 
+        const totalGlobal = totals.reduce((a, b) => a + b, 0);
         const typesEntries = Object.entries(types);
+
+        const tableHeader = typesEntries
+            .map(([name]) => `<th>${name}</th>`)
+            .join("");
+
+        const tableFooter = typesEntries
+            .map(([, value]) => `<td>${value || "0"}</td>`)
+            .join("");
+
+        const rows = listEntries
+            .map(([year, row], i) => `<tr>
+                <td>${year}</td>
+                ${typesEntries
+        .map(([name]) => `<td>${row[name] || "0"}</td>`)
+        .join("")
+}
+                <td>${totals[i] || "0"}</td>
+            </tr>`)
+            .join("");
 
         HTML.beforeBegin(
             document.querySelector(".youraccount_page > .block"),
@@ -38,28 +54,13 @@ export default class FLincensesSummary extends Feature {
                         <tbody>
                             <tr>
                                 <th>${Localization.str.year}</th>
-                                ${typesEntries
-        .map(([name]) => `<th>${name}</th>`)
-        .join("")
-}
+                                ${tableHeader}
                                 <th>${Localization.str.all}</th>
                             </tr>
-                            ${listEntries
-        .map(([year, row], i) => `<tr>
-                                <td>${year}</td>
-                                ${typesEntries
-        .map(([name]) => `<td>${row[name] || "0"}</td>`)
-        .join("")
-}
-                                <td>${totals[i] || "0"}</td>
-                            </tr>`)
-        .join("")}
+                            ${rows}
                             <tr>
                                 <td>${Localization.str.all}</td>
-                                ${typesEntries
-        .map(([, value]) => `<td>${value || "0"}</td>`)
-        .join("")
-}
+                                ${tableFooter}
                                 <td>${totalGlobal}</td>
                             </tr>
                         </tbody>

--- a/src/js/Content/Features/Store/Licenses/PLicenses.js
+++ b/src/js/Content/Features/Store/Licenses/PLicenses.js
@@ -1,0 +1,4 @@
+import {StorePage} from "../../StorePage";
+import {CLicenses} from "./CLicenses";
+
+(new StorePage()).run(CLicenses);


### PR DESCRIPTION
Do you ever wonder how many games you bought in a certain year as opposed to just claiming them for free?
Or how many games you were gifted in total? All the data is there, you just need to crunch some numbers, now automated!

Applies to [Home > Account > Licenses and product key activations](https://store.steampowered.com/account/licenses/)

Adds a summary table of games added to the account per year per category.

![image](https://github.com/IsThereAnyDeal/AugmentedSteam/assets/6942070/6a25ee43-99d1-43e0-9f42-d443245d8de2)

Tested in Chrome.
Fully translated using existing Localization lines.