### PR TITLE
Add 10px bottom margin to drm warning to match other UI

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -378,6 +378,7 @@ img.astats_icon {
   padding-bottom: 8px;
   min-height: 38px;
   background: linear-gradient(rgb(73, 22, 26) 0%, rgb(191, 48, 34) 100%);
+  margin-bottom: 10px;
 }
 .es_drm_warning span {
   display: table-cell;


### PR DESCRIPTION
Other elements on the page with solid backgrounds have bottom margins to space them out so they don't touch. This includes product/bundle purchase boxes, SteamDB pricing, Franchise links, etc. This PR adds such a margin to `es_drm_warning` so that it doesn't visually connect to whatever element appears below it.

Fixes #1736 

