### PR TITLE
Show DRM notices as the first child of the purchase area

### DIFF
--- a/src/js/Content/Features/Store/Common/FDRMWarnings.js
+++ b/src/js/Content/Features/Store/Common/FDRMWarnings.js
@@ -135,15 +135,10 @@ export default class FDRMWarnings extends Feature {
         }
 
         if (drmString) {
-            const html = `<div class="es_drm_warning"><span>${drmString}</span></div>`;
-
-            // Insert the notice after the "Buy this game as a gift for a friend" note if present
-            const node = document.querySelector("#game_area_purchase .game_area_description_bodylabel");
-            if (node) {
-                HTML.afterEnd(node, html);
-            } else {
-                HTML.afterBegin("#game_area_purchase, #game_area_purchase_top", html);
-            }
+            HTML.afterBegin(
+                "#game_area_purchase, #game_area_purchase_top",
+                `<div class="es_drm_warning"><span>${drmString}</span></div>`
+            );
         }
     }
 }


### PR DESCRIPTION
Avoid inserting the notice after the "Buy this game as a gift for a friend" note.

After this and #1737, the layout should now look like
![螢幕擷取畫面 2023-09-10 035234](https://github.com/IsThereAnyDeal/AugmentedSteam/assets/54083835/86563219-3a1b-4f1a-bc07-7e2816f3e8c4)

which feels more natural IMO.