### PR TITLE
Improve no-redirect handling for free promotions

### DIFF
--- a/src/js/Content/Features/Community/FriendsAndGroups/FGroupsManageButton.js
+++ b/src/js/Content/Features/Community/FriendsAndGroups/FGroupsManageButton.js
@@ -137,6 +137,6 @@ export default class FGroupsManageButton extends CallbackFeature {
             "steamids[]": id
         };
 
-        return RequestData.post(this._endpoint, data, {}, true);
+        return RequestData.post(this._endpoint, data);
     }
 }

--- a/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
+++ b/src/js/Content/Features/Community/Inventory/FQuickSellOptions.js
@@ -116,7 +116,7 @@ export default class FQuickSellOptions extends CallbackFeature {
                 "price": sellPrice
             };
 
-            const result = await RequestData.post("https://steamcommunity.com/market/sellitem/", data, {}, true).catch(err => err);
+            const result = await RequestData.post("https://steamcommunity.com/market/sellitem/", data).catch(err => err);
 
             if (!result?.success) {
                 loadingEl.textContent = result?.message ?? Localization.str.error;

--- a/src/js/Content/Features/Community/Workshop.js
+++ b/src/js/Content/Features/Community/Workshop.js
@@ -8,7 +8,7 @@ export default class Workshop {
 
         const data = {"sessionid": User.sessionId, appid, id};
 
-        const res = await RequestData.post(`https://steamcommunity.com/sharedfiles/${_method}`, data, {}, true);
+        const res = await RequestData.post(`https://steamcommunity.com/sharedfiles/${_method}`, data);
 
         if (method === "subscribe") {
             // https://github.com/SteamDatabase/SteamTracking/blob/3ab40a4604426852de8a51c50d963978e9660de4/steamcommunity.com/public/javascript/sharedfiles_functions_logged_in.js#L533

--- a/src/js/Content/Features/Store/RegisterKey/FMultiProductKeys.js
+++ b/src/js/Content/Features/Store/RegisterKey/FMultiProductKeys.js
@@ -90,18 +90,17 @@ export default class FMultiProductKeys extends Feature {
                     "product_key": currentKey
                 };
 
-                const request = RequestData.post("https://store.steampowered.com/account/ajaxregisterkey", data).then(response => {
-                    const _data = JSON.parse(response);
+                const request = RequestData.post("https://store.steampowered.com/account/ajaxregisterkey", data).then(result => {
                     const attempted = currentKey;
                     let message = Localization.str.register.default;
-                    if (_data.success === 1) {
+                    if (result.success === 1) {
                         document.querySelector(`#attempt_${attempted}_icon img`).setAttribute("src", ExtensionResources.getURL("img/sr/okay.png"));
-                        if (_data.purchase_receipt_info.line_items.length > 0) {
-                            document.querySelector(`#attempt_${attempted}_result`).textContent = Localization.str.register.success.replace("__gamename__", _data.purchase_receipt_info.line_items[0].line_item_description);
+                        if (result.purchase_receipt_info.line_items.length > 0) {
+                            document.querySelector(`#attempt_${attempted}_result`).textContent = Localization.str.register.success.replace("__gamename__", result.purchase_receipt_info.line_items[0].line_item_description);
                             document.querySelector(`#attempt_${attempted}_result`).style.display = "block";
                         }
                     } else {
-                        switch (_data.purchase_result_details) {
+                        switch (result.purchase_result_details) {
                             case 9: message = Localization.str.register.owned; break;
                             case 13: message = Localization.str.register.notavail; break;
                             case 14: message = Localization.str.register.invalid; break;

--- a/src/js/Content/Modules/RequestData.js
+++ b/src/js/Content/Modules/RequestData.js
@@ -30,27 +30,22 @@ class RequestData {
 
         ProgressBar.finishRequest();
 
-        return responseType === "none" ? response : response[responseType]();
+        return await response[responseType]();
     }
 
-    static post(url, data, settings = {}, returnJSON = false) {
+    static async post(url, data, settings = {}, returnJSON = true) {
 
         const _settings = {
-            ...settings,
             "method": "POST",
-            "body": new URLSearchParams(data)
+            "body": new URLSearchParams(data),
+            "credentials": "include",
+            "headers": {"origin": window.location.origin},
+            "referrer": window.location.origin + window.location.pathname,
+            ...settings
         };
 
-        let _responseType;
-        if (typeof returnJSON === "string") {
-            _responseType = returnJSON;
-        } else if (returnJSON) {
-            _responseType = "json";
-        } else {
-            _responseType = "text";
-        }
-
-        return RequestData.getHttp(url, _settings, _responseType);
+        const response = await RequestData._fetchFn(url, _settings);
+        return returnJSON ? await response.json() : response;
     }
 
     static getJson(url, settings) {

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -2,6 +2,7 @@
     "delete_comment_prompt": "Are you sure you want to delete this comment?",
     "addtocart_dialog": {
         "error_desc": "An error occurred while adding your item to Cart.",
+        "error_desc_freepromo": "An error occurred while adding this item to your account.",
         "title": "Added to Shopping Cart",
         "desc": "The item was added to your Shopping Cart.",
         "checkout": "No, checkout",
@@ -35,6 +36,7 @@
     },
     "cart": "Cart",
     "in_cart": "In Cart",
+    "in_account": "In Account",
     "steamid_of_user": "__user__'s SteamID",
     "copied": "Copied to your clipboard!",
     "view_steamid": "View SteamID",


### PR DESCRIPTION
This makes it so we handle free promotions the same as Steam's "Add to Library" option, instead of going through checkout.

Also decoupled `RequestData.post` from `RequestData.getHttp`. Almost all endpoints we send `POST` requests to return JSON data, and we have error handling in case the request failed so it's not really necessary to use the progress bar.

TODO:
1. Test actual cases.
2. Add translation for error codes?