### PR TITLE
Update covered stores from ITAD

### DIFF
--- a/src/js/Background/Modules/ExtensionData.js
+++ b/src/js/Background/Modules/ExtensionData.js
@@ -1,4 +1,3 @@
-import {SyncedStorage} from "../../modulesCore";
 import {IndexedDB} from "./IndexedDB";
 import CacheStorage from "./CacheStorage";
 
@@ -6,20 +5,6 @@ class ExtensionData {
     static clearCache() {
         CacheStorage.clear();
         return IndexedDB.clear();
-    }
-
-    /*
-     * TEMP(1.4.1)
-     * TODO delete after few versions
-     */
-    static async moveNotesToSyncedStorage() {
-        const idbNotes = Object.entries(await IndexedDB.getAll("notes"));
-
-        const notes = SyncedStorage.get("user_notes");
-        for (const [appid, note] of idbNotes) {
-            notes[appid] = note;
-        }
-        SyncedStorage.set("user_notes", notes);
     }
 
     static async getNote(appids) {

--- a/src/js/Background/Modules/ITADApi.js
+++ b/src/js/Background/Modules/ITADApi.js
@@ -7,6 +7,15 @@ const MAX_ITEMS_PER_REQUEST = 1000;
 
 class ITADApi extends Api {
 
+    static getStoreList() {
+        return IndexedDB.getAll("storeList");
+    }
+
+    static async fetchStoreList() {
+        const storeList = await ITADApi.getEndpoint("v01/web/stores/all/");
+        await IndexedDB.put("storeList", storeList);
+    }
+
     static async authorize() {
         const rnd = crypto.getRandomValues(new Uint32Array(1))[0];
         const redirectURI = "https://isthereanydeal.com/connectaugmentedsteam";

--- a/src/js/Background/Modules/IndexedDB.js
+++ b/src/js/Background/Modules/IndexedDB.js
@@ -39,6 +39,10 @@ class IndexedDB {
                     tx.objectStore("workshopFileSizes").deleteIndex("expiry");
                     tx.objectStore("reviews").deleteIndex("expiry");
                 }
+
+                if (oldVersion < 4) {
+                    db.createObjectStore("storeList");
+                }
             },
             blocked() {
                 console.error("Failed to upgrade database, there is already an open connection");
@@ -437,6 +441,7 @@ IndexedDB.timestampedStores = new Map([
     ["rates", 60 * 60],
     ["collection", 15 * 60],
     ["waitlist", 15 * 60],
+    ["storeList", 7 * 24 * 60 * 60],
 ]);
 
 IndexedDB.timestampedEntriesStores = new Map([

--- a/src/js/Background/background.js
+++ b/src/js/Background/background.js
@@ -29,6 +29,7 @@ IndexedDB.objStoreFetchFns = new Map([
 
     ["collection", ITADApi.endpointFactoryCached("v02/user/coll/all", "collection", ITADApi.mapCollection)],
     ["waitlist", ITADApi.endpointFactoryCached("v01/user/wait/all", "waitlist", ITADApi.mapWaitlist)],
+    ["storeList", ITADApi.fetchStoreList],
 ]);
 
 const actionCallbacks = new Map([
@@ -96,6 +97,7 @@ const actionCallbacks = new Map([
     ["itad.removefromwaitlist", ITADApi.removeFromWaitlist],
     ["itad.incollection", ITADApi.inCollection],
     ["itad.getfromcollection", ITADApi.getFromCollection],
+    ["itad.storelist", ITADApi.getStoreList],
 
     ["error.test", () => { return Promise.reject(new Error("This is a TEST Error. Please ignore.")); }],
 ]);

--- a/src/js/Background/background.js
+++ b/src/js/Background/background.js
@@ -39,7 +39,6 @@ const actionCallbacks = new Map([
     ["steam.currencies", StaticResources.currencies],
 
     ["migrate.cachestorage", CacheStorage.migrate],
-    ["migrate.notesToSyncedStorage", ExtensionData.moveNotesToSyncedStorage],
 
     ["notes.get", ExtensionData.getNote],
     ["notes.set", ExtensionData.setNote],

--- a/src/js/Core/Info.ts
+++ b/src/js/Core/Info.ts
@@ -2,5 +2,5 @@ import browser from "webextension-polyfill";
 
 export const Info = {
     "version": browser.runtime.getManifest().version,
-    "db_version": 3,
+    "db_version": 4,
 } as const;

--- a/src/js/Core/Storage/SyncedStorage.ts
+++ b/src/js/Core/Storage/SyncedStorage.ts
@@ -1,6 +1,7 @@
 import {type Key, default as Storage, type Value} from "./Storage";
 import {Info} from "../Info";
 import browser from "webextension-polyfill";
+import {StoreList} from "../../Options/Modules/Data/StoreList";
 
 // FIXME browser.storage.sync is still restricted (in terms of quota limits) even if the user hasn't enabled sync
 
@@ -25,6 +26,20 @@ class SyncedStorage<Defaults extends Record<Key, Value>> extends Storage<Default
             defaults,
             persistent,
         );
+    }
+
+    protected override async migrate(): Promise<void> {
+
+        // TODO Remove after some versions (added v2.5.1)
+        if (this.has("stores")) {
+            const stores = this.get("stores");
+            if (stores.length !== 0) {
+                const excludedStores = StoreList.map(({id}) => id).filter(id => !stores.includes(id));
+                await this.set("excluded_stores", excludedStores);
+            }
+
+            await this.remove("stores");
+        }
     }
 }
 
@@ -78,7 +93,7 @@ const DEFAULTS = {
     "showlowestprice_onwishlist": true,
     "showlowestpricecoupon": true,
     "showallstores": true,
-    "stores": [],
+    "excluded_stores": [],
     "override_price": "auto",
     "showregionalprice": "mouse",
     "regional_countries": ["us", "gb", "ru", "br", "au", "jp"],

--- a/src/js/Options/Modules/ChangelogBuilder.js
+++ b/src/js/Options/Modules/ChangelogBuilder.js
@@ -1,5 +1,4 @@
-import {ExtensionResources} from "../../Core/ExtensionResources";
-import {HTML} from "../../Core/Html/Html";
+import {ExtensionResources, HTML} from "../../modulesCore";
 
 class ChangelogBuilder {
 
@@ -9,18 +8,13 @@ class ChangelogBuilder {
         let html = "";
         for (const [version, logHtml] of Object.entries(data)) {
 
-            html += `
-                <div class="changelog__release">
-                    <h2 class="changelog__version">${version}</h2>
-                    <div class="changelog__log">${logHtml}</div>                
-                </div>
-            `;
+            html += `<div class="changelog__release">
+                        <h2 class="changelog__version">${version}</h2>
+                        <div class="changelog__log">${logHtml}</div>
+                    </div>`;
         }
 
-        HTML.inner(
-            document.querySelector(".js-changelog"),
-            html
-        );
+        HTML.inner(".js-changelog", html);
     }
 }
 

--- a/src/js/Options/Modules/Data/StoreList.js
+++ b/src/js/Options/Modules/Data/StoreList.js
@@ -1,3 +1,4 @@
+// TODO This is the old store list prior to v2.5, remove after some versions
 export const StoreList = [
     {
         "id": "game2",

--- a/src/js/Options/Modules/StoreListBuilder.js
+++ b/src/js/Options/Modules/StoreListBuilder.js
@@ -1,0 +1,33 @@
+import {BackgroundSimple, HTML, SyncedStorage} from "../../modulesCore";
+
+class StoreListBuilder {
+
+    constructor() {
+        this._container = document.querySelector(".js-store-stores");
+    }
+
+    async build() {
+
+        // This section is re-built on options reset
+        HTML.inner(this._container, "");
+
+        const storeList = await BackgroundSimple.action("itad.storelist").catch(err => console.error(err));
+        if (!storeList) { return; }
+
+        const excludedStores = SyncedStorage.get("excluded_stores");
+
+        let html = "";
+        for (const {id, title, color} of storeList.data) {
+            const checked = excludedStores.includes(id) ? "" : " checked";
+
+            html += `<div class="option option--store">
+                        <input type="checkbox" id="${id}"${checked}>
+                        <label for="${id}" style="color: ${color}">${title}</label>
+                    </div>`;
+        }
+
+        HTML.inner(this._container, html);
+    }
+}
+
+export {StoreListBuilder};

--- a/src/js/Options/options.js
+++ b/src/js/Options/options.js
@@ -1,3 +1,4 @@
+import {StoreListBuilder} from "./Modules/StoreListBuilder";
 import {ChangelogBuilder} from "./Modules/ChangelogBuilder";
 import {CustomLinks} from "./Modules/CustomLinks";
 import {Fader} from "./Modules/Fader";
@@ -12,7 +13,6 @@ import {
     Downloader, ExtensionResources, HTML, Info,
     Localization, PermissionOptions, Permissions, SyncedStorage
 } from "../modulesCore";
-import {StoreList} from "./Modules/Data/StoreList";
 import {ContextMenu} from "../Background/Modules/ContextMenu";
 import {UserNotesAdapter} from "../Core/Storage/UserNotesAdapter";
 import {BackgroundSimple} from "../Core/BackgroundSimple";
@@ -23,23 +23,6 @@ const Options = (() => {
     const self = {};
 
     let profileLinkImagesSelect;
-
-    function loadStores() {
-        const storesNode = document.querySelector(".js-store-stores");
-        const stores = SyncedStorage.get("stores");
-
-        let html = "";
-
-        for (const store of StoreList) {
-            const id = store.id;
-            html += `<div class="option option--store">
-                        <input type="checkbox" id="${id}"${(stores.length === 0 || stores.indexOf(id) !== -1) ? " checked" : ""}>
-                        <label for="${id}">${store.title}</label>
-                    </div>`;
-        }
-
-        HTML.inner(storesNode, html);
-    }
 
     function loadProfileLinkImages() {
 
@@ -73,9 +56,7 @@ const Options = (() => {
         }
     }
 
-    // Restores select box state to saved value from SyncStorage.
-    let changelogLoaded;
-
+    // Restores checkbox state to saved value from SyncedStorage
     function loadOptions() {
 
         // Set the value or state for each input
@@ -114,13 +95,9 @@ const Options = (() => {
             }
         }
 
-        if (!changelogLoaded) {
-            (new ChangelogBuilder()).build();
-            changelogLoaded = true;
-        }
+        (new StoreListBuilder()).build();
 
         loadProfileLinkImages();
-        loadStores();
 
         Region.populate();
         self.customLinks.forEach(option => option.populate());
@@ -192,12 +169,12 @@ const Options = (() => {
 
         let value;
 
-        if (option === "stores") {
+        if (option === "excluded_stores") {
 
             value = [];
             const nodes = document.querySelectorAll(".js-store-stores input[type=checkbox]");
             for (const node of nodes) {
-                if (node.checked) {
+                if (!node.checked) {
                     value.push(node.id);
                 }
             }
@@ -263,7 +240,7 @@ const Options = (() => {
         const node = e.target.closest("[data-setting]");
         if (!node) {
             if (e.target.closest(".js-store-stores")) {
-                saveOption("stores");
+                saveOption("excluded_stores");
             }
             return;
         }
@@ -320,6 +297,7 @@ const Options = (() => {
 
         await (new ITADConnectionManager()).run();
 
+        (new ChangelogBuilder()).build();
         (new LocaleCreditsBuilder()).build();
 
         function addHandlerToSetDefaultColor(key) {


### PR DESCRIPTION
Periodically fetch covered stores from ITAD instead of hardcoding them in the extension. Also migrated the `stores` key to `excluded_stores` so we can easily handle added stores (under the assumption that new stores are included by default).

1. `storeList` cache is set to 7 days.
2. I put the migration code unser `SyncedStorage`, because the Options page needs updated data too, but `UpdateHandler._migrateSettings` is only called on the content script side.
3. It shouldn't matter if the migrated `excluded_stores` contains stores that have been dropped. We'll fetch the current store list before fetching prices, and filter based on that. Once the user changes their preferences they'll be removed.
4. Tomas is open to adding the `exclude` param to the prices endpoint, but right now we can make-do.
5. Tomas said the new ITAD will use numbers instead of strings for store `id`s, so it's possible we'll need to do a second migration.