### PR TITLE
Fix disabling link filters due to Steam changes

### DIFF
--- a/src/js/Content/Features/Common/CBase.js
+++ b/src/js/Content/Features/Common/CBase.js
@@ -1,7 +1,6 @@
 import {Context} from "../../modulesContent";
 import FEarlyAccess from "./FEarlyAccess";
 import FHideTrademarks from "./FHideTrademarks";
-import FDisableLinkFilter from "./FDisableLinkFilter";
 import FKeepSSACheckboxState from "./FKeepSSACheckboxState";
 import FDefaultCommunityTab from "./FDefaultCommunityTab";
 import FFocusSearch from "./FFocusSearch";
@@ -13,7 +12,6 @@ export class CBase extends Context {
         features.push(
             FEarlyAccess,
             FHideTrademarks,
-            FDisableLinkFilter,
             FKeepSSACheckboxState,
             FDefaultCommunityTab,
             FFocusSearch,

--- a/src/js/Content/Features/Common/FDisableLinkFilter.js
+++ b/src/js/Content/Features/Common/FDisableLinkFilter.js
@@ -13,7 +13,13 @@ export default class FDisableLinkFilter extends Feature {
             const selector = "a[href*='/linkfilter/']";
 
             for (const link of parent.querySelectorAll(selector)) {
-                link.href = new URLSearchParams(link.search).get("url");
+                const params = new URLSearchParams(link.search);
+                if (params.has("u")) {
+                    link.href = params.get("u");
+                } else if (params.has("url")) {
+                    // TODO old param prior to 11/2023, remove after some time
+                    link.href = params.get("url");
+                }
             }
         }
 

--- a/src/js/Content/Features/Community/CCommunityBase.js
+++ b/src/js/Content/Features/Community/CCommunityBase.js
@@ -1,5 +1,6 @@
 import {CBase} from "../Common/CBase";
 import {ContextType} from "../../modulesContent";
+import FDisableLinkFilter from "../Common/FDisableLinkFilter";
 import FConfirmDeleteComment from "./FConfirmDeleteComment";
 import FHideSpamComments from "./FHideSpamComments";
 import FFavoriteEmoticons from "./FFavoriteEmoticons";
@@ -9,6 +10,7 @@ export class CCommunityBase extends CBase {
     constructor(type = ContextType.COMMUNITY_DEFAULT, features = []) {
 
         features.push(
+            FDisableLinkFilter,
             FConfirmDeleteComment,
             FHideSpamComments,
             FFavoriteEmoticons,

--- a/src/js/Content/Features/Store/App/CApp.js
+++ b/src/js/Content/Features/Store/App/CApp.js
@@ -3,6 +3,7 @@ import {Background, ContextType} from "../../../modulesContent";
 import {CStoreBase} from "../Common/CStoreBase";
 import {UserNotes} from "../Common/UserNotes";
 import FMediaExpander from "../../Common/FMediaExpander";
+import FDisableLinkFilter from "../../Common/FDisableLinkFilter";
 import FITADPrices from "../Common/FITADPrices";
 import FDRMWarnings from "../Common/FDRMWarnings";
 import FExtraLinks from "../Common/FExtraLinks";
@@ -61,6 +62,7 @@ export class CApp extends CStoreBase {
         }
 
         super(ContextType.APP, [
+            FDisableLinkFilter,
             FReplaceDevPubLinks,
             FForceMP4,
             FHDPlayer,


### PR DESCRIPTION
Fixes #1790.

Also made the feature only run on store app pages and the community, the reason being it registers a mutation observer on `document`, which is bad for React pages, and AFAIK these are the only places that external links can appear. Another area might be the custom links on curator pages (including creater and franchise), but we don't have dedicated scripts for these and IMO it's not worth it. Steam has also improved the way they handle link filters, so most sites (including developer websites) should already be whitelisted.