### PR TITLE
Avoid showing bundle header when there're no live bundles

### DIFF
--- a/src/js/Content/Modules/Prices/BundleOverview.svelte
+++ b/src/js/Content/Modules/Prices/BundleOverview.svelte
@@ -32,7 +32,7 @@
     });
 </script>
 
-{#if data.length > 0}
+{#if data.length > 0 && data.some(v => !v.expiry || Date.parse(v.expiry) > Date.now())}
     <h2 class="gradientbg es_external_icon">{Localization.str.bundle.header}</h2>
 
     {#each data as bundle}


### PR DESCRIPTION
The API returns all bundles now, so we need to add a check for live bundles.
Fixes #1837.