### PR TITLE
Fixup disable link filter handler

### DIFF
--- a/src/js/Content/Features/Common/FDisableLinkFilter.js
+++ b/src/js/Content/Features/Common/FDisableLinkFilter.js
@@ -8,20 +8,25 @@ export default class FDisableLinkFilter extends Feature {
     }
 
     apply() {
-        document.addEventListener("click", function(e) {
-            if (e.target.tagName && e.target.tagName === "A") {
-                let href = e.target.href;
-                if (/\/linkfilter\//.test(href)) {
-                    let params = new URLSearchParams(href.search);
-                    // TODO "url" param was used prior to 11/2023, remove after some time
-                    let url = params.get("u") ?? params.get("url");
-                    if (url) {
-                        // TODO check whether it's safe to just directly edit e.target.href
-                        window.location.href = url;
-                        e.preventDefault();
-                    }
-                }
-            }
+
+        document.addEventListener("click", e => {
+            if (e.target?.tagName !== "A") { return; }
+
+            const href = e.target.href;
+            if (!/\/linkfilter\//.test(href)) { return; }
+
+            const params = new URL(href).searchParams;
+            // TODO "url" param was used prior to 11/2023, remove after some time
+            const url = params.get("u") ?? params.get("url");
+            if (!url) { return; }
+
+            // Skip censored links (has '♥')
+            if (url.includes("%E2%99%A5")) { return; }
+
+            e.preventDefault();
+
+            // TODO check whether it's safe to just directly edit e.target.href
+            window.location.href = url;
         });
     }
 }


### PR DESCRIPTION
This feature wasn't working at all -- `href.search` was referencing the native String#search function. Also added a check to skip censored links.