### PR TITLE
Fix some feature dependencies

### DIFF
--- a/src/js/Content/Features/Store/App/CApp.js
+++ b/src/js/Content/Features/Store/App/CApp.js
@@ -139,8 +139,8 @@ export class CApp extends CStoreBase {
         // FPackBreakdown skips purchase options with a package info button to avoid false positives
         FeatureManager.dependency(FPackageInfoButton, [FPackBreakdown, true]);
 
-        // HDPlayer needs to wait for mp4 sources to be set
-        FeatureManager.dependency(FPackageInfoButton, [FPackBreakdown, true]);
+        // FHDPlayer needs to wait for mp4 sources to be set
+        FeatureManager.dependency(FHDPlayer, [FForceMP4, true]);
     }
 
     storePageDataPromise() {

--- a/src/js/Content/Features/Store/Wishlist/CWishlist.js
+++ b/src/js/Content/Features/Store/Wishlist/CWishlist.js
@@ -47,7 +47,7 @@ export class CWishlist extends CStoreBase {
         }
 
         // Maintain the order of the buttons
-        FeatureManager.dependency(FEmptyWishlist, [FExportWishlist, false]);
+        FeatureManager.dependency(FEmptyWishlist, [FExportWishlist, true]);
     }
 
     async applyFeatures() {


### PR DESCRIPTION
Fixes a copy error; the dependency on`FExportWishlist` should also be weak since it's just for display order.