### PR TITLE
Don't throw an error if game doesn't have cards

### DIFF
--- a/src/js/Content/Features/Store/App/FBadgeProgress.svelte
+++ b/src/js/Content/Features/Store/App/FBadgeProgress.svelte
@@ -25,7 +25,7 @@
 
             // No badge data if game doesn't have cards or not logged in
             if (!data) {
-                throw new Error("Failed to find badges data");
+                return;
             }
 
             let target = document.querySelector(".rightcol.game_meta_data");


### PR DESCRIPTION
It's perfectly normal for a game to not have cards, so avoid throwing an error. Fixup #1876.