### PR TITLE
Fix missing features on some store pages

### DIFF
--- a/src/js/Content/Features/Store/AgeCheck/CAgecheck.js
+++ b/src/js/Content/Features/Store/AgeCheck/CAgecheck.js
@@ -1,14 +1,13 @@
-import {Context, ContextType} from "../../../modulesContent";
+import {ContextType} from "../../../modulesContent";
+import {CStoreBase} from "../Common/CStoreBase";
 import FSkipAgecheck from "../../Common/FSkipAgecheck";
-import FFocusSearch from "../../Common/FFocusSearch";
 
-export class CAgeCheck extends Context {
+export class CAgeCheck extends CStoreBase {
 
     constructor() {
 
         super(ContextType.AGECHECK, [
             FSkipAgecheck,
-            FFocusSearch,
         ]);
     }
 }

--- a/src/js/Content/Features/Store/Cart/CCart.js
+++ b/src/js/Content/Features/Store/Cart/CCart.js
@@ -1,7 +1,8 @@
-import {Context, ContextType} from "../../../modulesContent";
+import {ContextType} from "../../../modulesContent";
+import {CStoreBase} from "../Common/CStoreBase";
 import FCartHistoryLink from "./FCartHistoryLink";
 
-export class CCart extends Context {
+export class CCart extends CStoreBase {
 
     constructor() {
 

--- a/src/js/Content/Features/Store/Funds/CFunds.js
+++ b/src/js/Content/Features/Store/Funds/CFunds.js
@@ -1,7 +1,8 @@
-import {Context, ContextType} from "../../../modulesContent";
+import {ContextType} from "../../../modulesContent";
+import {CStoreBase} from "../Common/CStoreBase";
 import FCustomGiftcardAndWallet from "./FCustomGiftcardAndWallet";
 
-export class CFunds extends Context {
+export class CFunds extends CStoreBase {
 
     constructor() {
 

--- a/src/js/Content/Features/Store/RegisterKey/CRegisterKey.js
+++ b/src/js/Content/Features/Store/RegisterKey/CRegisterKey.js
@@ -1,15 +1,12 @@
-import {Context, ContextType} from "../../../modulesContent";
-import FKeepSSACheckboxState from "../../Common/FKeepSSACheckboxState";
-import FFocusSearch from "../../Common/FFocusSearch";
+import {ContextType} from "../../../modulesContent";
+import {CStoreBase} from "../Common/CStoreBase";
 import FMultiProductKeys from "./FMultiProductKeys";
 
-export class CRegisterKey extends Context {
+export class CRegisterKey extends CStoreBase {
 
     constructor() {
 
         super(ContextType.REGISTER_KEY, [
-            FKeepSSACheckboxState,
-            FFocusSearch,
             FMultiProductKeys,
         ]);
     }


### PR DESCRIPTION
These store page contexts need to extend `CStoreBase` to enable features like highlights in search results and focus search box by pressing "s". I might have broken these a while ago 😅