### PR TITLE
Remove redundant async/await from background handler

### DIFF
--- a/src/js/Background/MessageHandlerInterface.ts
+++ b/src/js/Background/MessageHandlerInterface.ts
@@ -1,4 +1,4 @@
 
 export default interface MessageHandlerInterface {
-    handle(message: any): Promise<any|undefined>;
+    handle(message: any): symbol|Promise<any>;
 }

--- a/src/js/Background/Modules/AugmentedSteam/AugmentedSteamApi.ts
+++ b/src/js/Background/Modules/AugmentedSteam/AugmentedSteamApi.ts
@@ -26,57 +26,57 @@ export default class AugmentedSteamApi extends Api implements MessageHandlerInte
         super(Config.ApiServerHost);
     }
 
-    private async fetchStorePageData(appid: number): Promise<TStorePageData> {
+    private fetchStorePageData(appid: number): Promise<TStorePageData> {
         const url = this.getUrl(`app/${appid}/v2`);
         return this.fetchJson(url);
     }
 
-    private async fetchRates(to: string[]): Promise<{[from: string]: {[to: string]: number}}> {
+    private fetchRates(to: string[]): Promise<{[from: string]: {[to: string]: number}}> {
         const url = this.getUrl(`rates/v1`, {to: to.join(",")});
-        return await this.fetchJson(url);
+        return this.fetchJson(url);
     }
 
-    private async fetchEarlyAccess(): Promise<Array<number>> {
+    private fetchEarlyAccess(): Promise<Array<number>> {
         const url = this.getUrl("early-access/v1");
         return this.fetchJson(url);
     }
 
-    private async fetchSteamPeek(appid: number): Promise<TSimilarResponse> {
+    private fetchSteamPeek(appid: number): Promise<TSimilarResponse> {
         const url = this.getUrl(`similar/${appid}/v2`, {count: 15});
-        return await this.fetchJson(url);
+        return this.fetchJson(url);
     }
 
-    private async fetchDlcInfo(appid: number): Promise<TDlcInfo> {
+    private fetchDlcInfo(appid: number): Promise<TDlcInfo> {
         const url = this.getUrl(`dlc/${appid}/v2`);
         return this.fetchJson<TDlcInfo>(url);
     }
 
-    private async fetchProfile(steamId: string): Promise<TProfileData> {
+    private fetchProfile(steamId: string): Promise<TProfileData> {
         const url = this.getUrl(`profile/${steamId}/v2`);
-        return await this.fetchJson(url);
+        return this.fetchJson(url);
     }
 
-    private async fetchTwitch(twitchChannelId: string): Promise<TFetchTwitchStreamResponse> {
+    private fetchTwitch(twitchChannelId: string): Promise<TFetchTwitchStreamResponse> {
         const url = this.getUrl(`twitch/${twitchChannelId}/stream/v2`);
         return this.fetchJson<TFetchTwitchStreamResponse>(url);
     }
 
-    private async fetchProfileBackgrounds(appid: number): Promise<TFetchProfileBackgroundsResponse> {
+    private fetchProfileBackgrounds(appid: number): Promise<TFetchProfileBackgroundsResponse> {
         const url = this.getUrl("profile/background/list/v2", {appid});
         return this.fetchJson<TFetchProfileBackgroundsResponse>(url);
     }
 
-    private async fetchProfileBackgroundsGames(): Promise<TFetchProfileBackgroundsGamesResponse> {
+    private fetchProfileBackgroundsGames(): Promise<TFetchProfileBackgroundsGamesResponse> {
         const url = this.getUrl("profile/background/games/v1");
         return this.fetchJson<TFetchProfileBackgroundsGamesResponse>(url);
     }
 
-    private async fetchMarketCardPrices(currency: string, appid: number): Promise<TFetchMarketCardPricesResponse> {
+    private fetchMarketCardPrices(currency: string, appid: number): Promise<TFetchMarketCardPricesResponse> {
         const url = this.getUrl("market/cards/v2", {currency, appid});
         return this.fetchJson(url);
     }
 
-    private async fetchMarketAverageCardPrices(currency: string, appids: number[]): Promise<TFetchMarketCardAveragePricesResponse> {
+    private fetchMarketAverageCardPrices(currency: string, appids: number[]): Promise<TFetchMarketCardAveragePricesResponse> {
         const url = this.getUrl("market/cards/average-prices/v2", {
             currency,
             appids: appids.join(",")
@@ -84,7 +84,7 @@ export default class AugmentedSteamApi extends Api implements MessageHandlerInte
         return this.fetchJson(url);
     }
 
-    private async fetchPrices(
+    private fetchPrices(
         country: string,
         apps: number[],
         subs: number[],
@@ -94,7 +94,7 @@ export default class AugmentedSteamApi extends Api implements MessageHandlerInte
     ): Promise<TFetchPricesResponse> {
         const url = this.getUrl("prices/v2");
 
-        return await this.fetchJson<TFetchPricesResponse>(url, {
+        return this.fetchJson<TFetchPricesResponse>(url, {
             method: "POST",
             body: JSON.stringify({country, apps, subs, bundles, voucher, shops})
         });
@@ -122,6 +122,7 @@ export default class AugmentedSteamApi extends Api implements MessageHandlerInte
 
     async getStorePageData(appid: number): Promise<TStorePageData> {
         const ttl = 60*60;
+
         let data = await IndexedDB.get("storePageData", appid);
 
         if (!data || TimeUtils.isInPast(data.expiry)) {
@@ -129,9 +130,9 @@ export default class AugmentedSteamApi extends Api implements MessageHandlerInte
                 data: await this.fetchStorePageData(appid),
                 expiry: TimeUtils.now() + ttl
             }
-
-            await IndexedDB.put("storePageData", data,appid);
+            await IndexedDB.put("storePageData", data, appid);
         }
+
         return data.data;
     }
 
@@ -176,57 +177,56 @@ export default class AugmentedSteamApi extends Api implements MessageHandlerInte
         return IndexedDB.contains("earlyAccessAppids", appids);
     }
 
-    async handle(message: any) {
+    handle(message: any): typeof Unrecognized|Promise<any> {
 
         switch (message.action) {
 
             case EAction.Prices: {
-                const params = message.params;
-                const {country, apps, subs, bundles, voucher, shops} = params;
-                return await this.fetchPrices(country, apps, subs, bundles, voucher, shops);
+                const {country, apps, subs, bundles, voucher, shops} = message.params;
+                return this.fetchPrices(country, apps, subs, bundles, voucher, shops);
             }
 
             case EAction.DlcInfo:
-                return await this.fetchDlcInfo(message.params.appid);
+                return this.fetchDlcInfo(message.params.appid);
 
             case EAction.StorePageData:
-                return await this.getStorePageData(message.params.appid);
+                return this.getStorePageData(message.params.appid);
 
             case EAction.StorePageData_Expire:
-                return await this.expireStorePageData(message.params.appid);
+                return this.expireStorePageData(message.params.appid);
 
             case EAction.Rates:
-                return await this.getRates(message.params.to);
+                return this.getRates(message.params.to);
 
             case EAction.Rates_Clear:
-                return await this.clearRates();
+                return this.clearRates();
 
             case EAction.IsEA:
-                return await this.isEarlyAccess(message.params.appids);
+                return this.isEarlyAccess(message.params.appids);
 
             case EAction.ProfileBackground:
-                return await this.fetchProfileBackgrounds(message.params.appid);
+                return this.fetchProfileBackgrounds(message.params.appid);
 
             case EAction.ProfileBackgroundGames:
-                return await this.fetchProfileBackgroundsGames();
+                return this.fetchProfileBackgroundsGames();
 
             case EAction.TwitchStream:
-                return await this.fetchTwitch(message.params.channelId);
+                return this.fetchTwitch(message.params.channelId);
 
             case EAction.Market_CardPrices:
-                return await this.fetchMarketCardPrices(message.params.currency, message.params.appid);
+                return this.fetchMarketCardPrices(message.params.currency, message.params.appid);
 
             case EAction.Market_AverageCardPrices:
-                return await this.fetchMarketAverageCardPrices(message.params.currency, message.params.appids);
+                return this.fetchMarketAverageCardPrices(message.params.currency, message.params.appids);
 
             case EAction.SteamPeek:
-                return await this.fetchSteamPeek(message.params.appid);
+                return this.fetchSteamPeek(message.params.appid);
 
             case EAction.Profile:
-                return await this.getProfileData(message.params.steamId);
+                return this.getProfileData(message.params.steamId);
 
             case EAction.Profile_Clear:
-                return await this.clearOwn(message.params.steamId);
+                return this.clearOwn(message.params.steamId);
         }
 
         return Unrecognized;

--- a/src/js/Background/Modules/Cache/CacheApi.ts
+++ b/src/js/Background/Modules/Cache/CacheApi.ts
@@ -32,11 +32,11 @@ export default class CacheApi implements MessageHandlerInterface{
         );
     }
 
-    async handle(message: any) {
+    handle(message: any): typeof Unrecognized|Promise<any> {
 
         switch (message.action) {
             case EAction.CacheClear: {
-                return await this.clearCache();
+                return this.clearCache();
             }
         }
 

--- a/src/js/Background/Modules/Community/SteamCommunityApi.ts
+++ b/src/js/Background/Modules/Community/SteamCommunityApi.ts
@@ -30,6 +30,7 @@ export default class SteamCommunityApi extends Api implements MessageHandlerInte
 
         return await response.text();
     }
+
     private fetchBadgeInfo(steamid: string, appid: number): Promise<TFetchBadgeInfoResponse> {
         const url = this.getUrl(`/profiles/${steamid}/ajaxgetbadgeinfo/${appid}`);
         return this.fetchJson(url, {credentials: "include"});
@@ -167,30 +168,30 @@ export default class SteamCommunityApi extends Api implements MessageHandlerInte
         return (await LocalStorage.get("storeCountry")) ?? null;
     }
 
-    async handle(message: any): Promise<any> {
+    handle(message: any): typeof Unrecognized|Promise<any> {
 
         switch(message.action) {
 
             case EAction.BadgeInfo:
-                return await this.fetchBadgeInfo(message.params.steamId, message.params.appid);
+                return this.fetchBadgeInfo(message.params.steamId, message.params.appid);
 
             case EAction.WorkshopFileSize:
-                return await this.getWorkshopFileSize(message.params.id, message.params.preventFetch);
+                return this.getWorkshopFileSize(message.params.id, message.params.preventFetch);
 
             case EAction.Reviews:
-                return await this.getReviews(message.params.steamId, message.params.pages);
+                return this.getReviews(message.params.steamId, message.params.pages);
 
             case EAction.Login:
-                return await this.login(message.params.profilePath);
+                return this.login(message.params.profilePath);
 
             case EAction.Logout:
-                return await this.logout(message.params.force ?? undefined);
+                return this.logout(message.params.force ?? undefined);
 
             case EAction.StoreCountry_Set:
-                return await this.setStoreCountry(message.params.newCountry);
+                return this.setStoreCountry(message.params.newCountry);
 
             case EAction.StoreCountry_Get:
-                return await this.getStoreCountry();
+                return this.getStoreCountry();
         }
 
         return Unrecognized;

--- a/src/js/Background/Modules/Inventory/InventoryApi.ts
+++ b/src/js/Background/Modules/Inventory/InventoryApi.ts
@@ -312,23 +312,23 @@ export default class InventoryApi extends Api implements MessageHandlerInterface
         return await IndexedDB.contains("items", hashes);
     }
 
-    async handle(message: any): Promise<any> {
+    handle(message: any): typeof Unrecognized|Promise<any> {
 
         switch(message.action) {
             case EAction.Inventory_GetCoupon:
-                return await this.getCoupon(message.params.appid);
+                return this.getCoupon(message.params.appid);
 
             case EAction.Inventory_GetCouponsAppids:
-                return await this.getCouponsAppids(message.params.appids);
+                return this.getCouponsAppids(message.params.appids);
 
             case EAction.Inventory_GetGiftsAppids:
-                return await this.getGiftsAppids(message.params.appids);
+                return this.getGiftsAppids(message.params.appids);
 
             case EAction.Inventory_GetPassesAppids:
-                return await this.getPassesAppids(message.params.appids);
+                return this.getPassesAppids(message.params.appids);
 
             case EAction.Inventory_HasItem:
-                return await this.hasItem(message.params.hashes);
+                return this.hasItem(message.params.hashes);
         }
 
         return Unrecognized;

--- a/src/js/Background/Modules/IsThereAnyDeal/ITADApi.ts
+++ b/src/js/Background/Modules/IsThereAnyDeal/ITADApi.ts
@@ -344,7 +344,7 @@ export default class ITADApi extends Api implements MessageHandlerInterface {
         return (await IndexedDB.get("collection", storeId)) ?? null;
     }
 
-    async handle(message: any) {
+    handle(message: any): typeof Unrecognized|Promise<any> {
 
         switch(message.action) {
             case EAction.StoreList:

--- a/src/js/Background/Modules/Store/SteamStoreApi.ts
+++ b/src/js/Background/Modules/Store/SteamStoreApi.ts
@@ -367,41 +367,41 @@ export default class SteamStoreApi extends Api implements MessageHandlerInterfac
         return null;
     }
 
-    async handle(message: any): Promise<any> {
+    handle(message: any): typeof Unrecognized|Promise<any> {
 
         switch(message.action) {
             case EAction.Wishlist_Add:
-                return await this.wishlistAdd(message.params.appid);
+                return this.wishlistAdd(message.params.appid);
 
             case EAction.Wishlist_Remove:
-                return await this.wishlistRemove(message.params.appid);
+                return this.wishlistRemove(message.params.appid);
 
             case EAction.Wishlists:
-                return await this.fetchWishlistCount(message.params.path);
+                return this.fetchWishlistCount(message.params.path);
 
             case EAction.AppDetails:
-                return await this.fetchAppDetails(message.params.appid, message.params.filter ?? undefined);
+                return this.fetchAppDetails(message.params.appid, message.params.filter ?? undefined);
 
             case EAction.Currency:
-                return await this.getCurrency();
+                return this.getCurrency();
 
             case EAction.SessionId:
-                return await this.fetchSessionId();
+                return this.fetchSessionId();
 
             case EAction.Purchases:
-                return await this.getPurchaseDate(message.params.appName, message.params.lang);
+                return this.getPurchaseDate(message.params.appName, message.params.lang);
 
             case EAction.Purchases_Clear:
-                return await this.clearPurchases();
+                return this.clearPurchases();
 
             case EAction.DynamicStore_Clear:
-                return await this.clearDynamicStore();
+                return this.clearDynamicStore();
 
             case EAction.DynamicStore_Status:
-                return await this.getDynamicStoreStatus(message.params.ids);
+                return this.getDynamicStoreStatus(message.params.ids);
 
             case EAction.DynamicStore_RandomApp:
-                return await this.dynamicStoreRandomApp();
+                return this.dynamicStoreRandomApp();
         }
 
         return Unrecognized;

--- a/src/js/Background/Modules/UserNotes/UserNotesApi.ts
+++ b/src/js/Background/Modules/UserNotes/UserNotesApi.ts
@@ -5,7 +5,7 @@ import {Unrecognized} from "@Background/background";
 
 export default class UserNotesApi implements MessageHandlerInterface {
 
-    private async getNote(appids: number[]): Promise<Record<number, string|undefined>> {
+    private getNote(appids: number[]): Promise<Record<number, string|undefined>> {
         return IndexedDB.getObject("notes", appids);
     }
 
@@ -41,26 +41,26 @@ export default class UserNotesApi implements MessageHandlerInterface {
         return IndexedDB.clear("notes");
     }
 
-    async handle(message: any): Promise<any> {
+    handle(message: any): typeof Unrecognized|Promise<any> {
 
         switch(message.action) {
             case EAction.Notes_Get:
-                return await this.getNote(message.params.appids);
+                return this.getNote(message.params.appids);
 
             case EAction.Notes_Set:
-                return await this.setNote(message.params.appid, message.params.note);
+                return this.setNote(message.params.appid, message.params.note);
 
             case EAction.Notes_Delete:
-                return await this.deleteNote(message.params.appid);
+                return this.deleteNote(message.params.appid);
 
             case EAction.Notes_GetAll:
-                return await this.getAllNotes();
+                return this.getAllNotes();
 
             case EAction.Notes_SetAll:
-                return await this.setAllNotes(message.params.notes);
+                return this.setAllNotes(message.params.notes);
 
             case EAction.Notes_Clear:
-                return await this.clearNotes();
+                return this.clearNotes();
         }
 
         return Unrecognized;

--- a/src/js/Content/Modules/Facades/SteamCommunityApiFacade.ts
+++ b/src/js/Content/Modules/Facades/SteamCommunityApiFacade.ts
@@ -4,31 +4,31 @@ import {EAction} from "@Background/EAction";
 
 export default class SteamCommunityApiFacade {
 
-    static async fetchBadgeInfo(steamId: string, appid: number): Promise<TFetchBadgeInfoResponse> {
-        return await Background.send(EAction.BadgeInfo, {steamId, appid});
+    static fetchBadgeInfo(steamId: string, appid: number): Promise<TFetchBadgeInfoResponse> {
+        return Background.send(EAction.BadgeInfo, {steamId, appid});
     }
 
-    static async getWorkshopFileSize(id: number, preventFetch: boolean): Promise<number|null> {
-        return await Background.send(EAction.WorkshopFileSize, {id, preventFetch});
+    static getWorkshopFileSize(id: number, preventFetch: boolean): Promise<number|null> {
+        return Background.send(EAction.WorkshopFileSize, {id, preventFetch});
     }
 
-    static async getReviews(steamId: string, pages: number): Promise<TFetchReviewsResponse> {
-        return await Background.send(EAction.Reviews, {steamId, pages});
+    static getReviews(steamId: string, pages: number): Promise<TFetchReviewsResponse> {
+        return Background.send(EAction.Reviews, {steamId, pages});
     }
 
-    static async login(profilePath: string): Promise<TLogin> {
-        return await Background.send(EAction.Login, {profilePath});
+    static login(profilePath: string): Promise<TLogin> {
+        return Background.send(EAction.Login, {profilePath});
     }
 
-    static async logout(force: boolean|undefined=undefined): Promise<void> {
-        return await Background.send(EAction.Logout, {force});
+    static logout(force: boolean|undefined=undefined): Promise<void> {
+        return Background.send(EAction.Logout, {force});
     }
 
-    static async setStoreCountry(newCountry: string): Promise<void> {
-        return await Background.send(EAction.StoreCountry_Set, {newCountry});
+    static setStoreCountry(newCountry: string): Promise<void> {
+        return Background.send(EAction.StoreCountry_Set, {newCountry});
     }
 
-    static async getStoreCountry(): Promise<string|null> {
-        return await Background.send(EAction.StoreCountry_Get);
+    static getStoreCountry(): Promise<string|null> {
+        return Background.send(EAction.StoreCountry_Get);
     }
 }

--- a/src/js/Content/Modules/Facades/SteamStoreApiFacade.ts
+++ b/src/js/Content/Modules/Facades/SteamStoreApiFacade.ts
@@ -4,43 +4,43 @@ import type {TAppDetail, TDynamicStoreStatusResponse, TFetchWishlistResponse} fr
 
 export default class SteamStoreApiFacade {
 
-    static async wishlistAdd(appid: number): Promise<void> {
-        return await Background.send(EAction.Wishlist_Add, {appid});
+    static wishlistAdd(appid: number): Promise<void> {
+        return Background.send(EAction.Wishlist_Add, {appid});
     }
 
-    static async wishlistRemove(appid: number): Promise<void> {
-        return await Background.send(EAction.Wishlist_Remove, {appid});
+    static wishlistRemove(appid: number): Promise<void> {
+        return Background.send(EAction.Wishlist_Remove, {appid});
     }
 
-    static async fetchWishlistCount(path: string): Promise<TFetchWishlistResponse> {
-        return await Background.send(EAction.Wishlists, {path});
+    static fetchWishlistCount(path: string): Promise<TFetchWishlistResponse> {
+        return Background.send(EAction.Wishlists, {path});
     }
 
-    static async fetchAppDetails(appid: number, filter: string|undefined=undefined): Promise<TAppDetail|null> {
-        return await Background.send(EAction.AppDetails, {appid, filter});
+    static fetchAppDetails(appid: number, filter: string|undefined=undefined): Promise<TAppDetail|null> {
+        return Background.send(EAction.AppDetails, {appid, filter});
     }
 
-    static async getPurchaseDate(appName: string, lang: string): Promise<string|null> {
-        return await Background.send(EAction.Purchases, {appName, lang});
+    static getPurchaseDate(appName: string, lang: string): Promise<string|null> {
+        return Background.send(EAction.Purchases, {appName, lang});
     }
 
-    static async getCurrency(): Promise<string> {
-        return await Background.send(EAction.Currency);
+    static getCurrency(): Promise<string> {
+        return Background.send(EAction.Currency);
     }
 
-    static async clearPurchases(): Promise<void> {
+    static clearPurchases(): Promise<void> {
         return Background.send(EAction.Purchases_Clear);
     }
 
-    static async clearDynamicStore(): Promise<void> {
+    static clearDynamicStore(): Promise<void> {
         return Background.send(EAction.DynamicStore_Clear);
     }
 
-    static async getDynamicStoreStatus(ids: string[]): Promise<TDynamicStoreStatusResponse> {
+    static getDynamicStoreStatus(ids: string[]): Promise<TDynamicStoreStatusResponse> {
         return Background.send(EAction.DynamicStore_Status, {ids});
     }
 
-    static async getDynamicStoreRandomApp(): Promise<number|null> {
+    static getDynamicStoreRandomApp(): Promise<number|null> {
         return Background.send(EAction.DynamicStore_RandomApp);
     }
 }


### PR DESCRIPTION
These seem redundant because the final value is awaited. Maybe a linter can catch these?