### PR TITLE
Fix steampeek hovers

### DIFF
--- a/src/js/Content/Features/Store/App/FSteamPeek.ts
+++ b/src/js/Content/Features/Store/App/FSteamPeek.ts
@@ -3,7 +3,6 @@ import {__moreOnSteampeek} from "@Strings/_strings";
 import type CApp from "@Content/Features/Store/App/CApp";
 import Feature from "@Content/Modules/Context/Feature";
 import HTML from "@Core/Html/Html";
-import DynamicStore from "@Content/Modules/Data/DynamicStore";
 import LocalStorage from "@Core/Storage/LocalStorage";
 import DOMHelper from "@Content/Modules/DOMHelper";
 import AugmentedSteamApiFacade from "@Content/Modules/Facades/AugmentedSteamApiFacade";
@@ -33,9 +32,6 @@ export default class FSteamPeek extends Feature<CApp> {
                     </div>
                 </div>
             </div>`);
-
-        await DynamicStore.onReady();
-
 
         const steamTab = this._moreLikeThis.querySelector("#es_tab_steamsimilar")!;
         const steamPeekTab = this._moreLikeThis.querySelector<HTMLElement>("#es_tab_steampeek")!;

--- a/src/js/Content/Features/Store/App/FSteamPeek.ts
+++ b/src/js/Content/Features/Store/App/FSteamPeek.ts
@@ -79,11 +79,9 @@ export default class FSteamPeek extends Feature<CApp> {
                             <img src="//cdn.cloudflare.steamstatic.com/steam/apps/${appid}/capsule_184x69.jpg" class="small_cap_img">
                             <h4>${title}</h4>
                         </a>`);
-
-                    DOMHelper.insertScript("scriptlets/Store/App/SteamPeek/bindHover.js", {appid});
                 }
 
-                DOMHelper.insertScript("scriptlets/Store/App/SteamPeek/decorateItems.js");
+                DOMHelper.insertScript("scriptlets/Store/App/SteamPeek/decorateItems.js", {appids: data.map(({appid}) => appid)});
                 this.context.decorateStoreCapsules(content.querySelectorAll<HTMLAnchorElement>("a.es_sp_similar"));
 
                 HTML.beforeBegin(lastChild,

--- a/src/scriptlets/Store/App/SteamPeek/bindHover.js
+++ b/src/scriptlets/Store/App/SteamPeek/bindHover.js
@@ -1,6 +1,0 @@
-(function(){
-    const params = JSON.parse(document.currentScript.dataset.params);
-    const {appid} = params;
-
-    GStoreItemData.BindHoverEvents($J("#recommended_block_content > a:last-of-type"), appid);
-})();

--- a/src/scriptlets/Store/App/SteamPeek/decorateItems.js
+++ b/src/scriptlets/Store/App/SteamPeek/decorateItems.js
@@ -1,3 +1,10 @@
 (function(){
+    const params = JSON.parse(document.currentScript.dataset.params);
+    const {appids} = params;
+
+    for (const appid of appids) {
+        GStoreItemData.BindHoverEvents($J(`#recommended_block_content > a[data-ds-appid="${appid}"]`), appid);
+    }
+
     GDynamicStore.DecorateDynamicItems($J("#recommended_block_content > a.es_sp_similar"));
 })();


### PR DESCRIPTION
The reason why it's broken seems to be because dynamic scripts are not guaranteed to run immediately and in the order they were inserted (so the `a:last-of-type` selector always selects the same node).

The way to avoid this potential footgun is to make `DOMHelper.insertScript` return a promise that resolves on load, but for this particular case, I think it's better to just run a single script instead.