### PR TITLE
Fix switching notes adapter

### DIFF
--- a/src/js/Content/Modules/UserNotes/UserNotesAdapter.ts
+++ b/src/js/Content/Modules/UserNotes/UserNotesAdapter.ts
@@ -3,28 +3,29 @@ import type AdapterInterface from "@Content/Modules/UserNotes/Adapters/AdapterIn
 import SyncedStorageAdapter from "@Content/Modules/UserNotes/Adapters/SyncedStorageAdapter";
 import IdbAdapter from "@Content/Modules/UserNotes/Adapters/IdbAdapter";
 import type {SettingsSchema} from "@Options/Data/_types";
+import assertNever from "@Core/AssertNever";
 
 // TODO merge with UserNotes class?
 
 export default class UserNotesAdapter {
 
-    private static adapter: any|undefined = undefined;
+    private static adapter: AdapterInterface;
 
-    private static createAdapter(type: SettingsSchema["user_notes_adapter"]): AdapterInterface {
+    private static createAdapter(type: SettingsSchema["user_notes_adapter"]) {
         switch (type) {
             case "synced_storage":
                 return new SyncedStorageAdapter();
 
             case "idb":
                 return new IdbAdapter();
-        }
 
-        // @ts-ignore extra safety
-        throw new Error();
+            default:
+                assertNever(type);
+        }
     }
 
     static getAdapter(): AdapterInterface {
-        if (!this.adapter) {
+        if (this.adapter === undefined) {
             this.adapter = this.createAdapter(Settings.user_notes_adapter);
         }
         return this.adapter;

--- a/src/js/Core/AssertNever.ts
+++ b/src/js/Core/AssertNever.ts
@@ -1,0 +1,3 @@
+export default function assertNever(_value: never): never {
+    throw new Error();
+}

--- a/src/js/Options/Modules/Options/StoreOptions.svelte
+++ b/src/js/Options/Modules/Options/StoreOptions.svelte
@@ -49,6 +49,7 @@
     import UserNotesAdapter from "@Content/Modules/UserNotes/UserNotesAdapter";
 
     let settings: Writable<SettingsSchema> = writable(Settings);
+    UserNotesAdapter.getAdapter(); // Set current adapter
 </script>
 
 


### PR DESCRIPTION
In the old options logic, `UserNotesAdapter.getAdapter` was called prior to the new value being saved to storage, but now by the time it's called the new value had already been saved, so we need to set the current adapter when loading options, otherwise it will always return the new adapter...

We should probably have error handling here as well.