### PR TITLE
Put class on bundle-tier to make it parsable later

### DIFF
--- a/src/js/Content/Modules/Prices/BundleOverview.svelte
+++ b/src/js/Content/Modules/Prices/BundleOverview.svelte
@@ -59,7 +59,7 @@
 
                 <p class="package_contents">
                     {#each bundle.tiers as tier, num}
-                        <b>
+                        <b class="es_bundle_tier_title">
                             {#if bundle.tiers.length > 1}
                                 {L(__bundle_tierIncludes, {
                                     "tier": L(__bundle_tier, {"num": num+1}),


### PR DESCRIPTION
Hello, I am one of the developers of the [Steam Currency Converter](https://chromewebstore.google.com/detail/steam-currency-converter/ocabaebkfcojookdnihccpcngaaigfan). 
 
We use AS daily and pay close attention to its newly introduced features. To improve price parsing on bundle tiers, we suggest adding a class name for those prices. This change would significantly ease our efforts in converting these prices.

Best regards.