### PR TITLE
Fix wait dialog status text handling

### DIFF
--- a/src/js/Content/Features/Community/MyWorkshop/FWorkshopFileSizes.ts
+++ b/src/js/Content/Features/Community/MyWorkshop/FWorkshopFileSizes.ts
@@ -20,6 +20,7 @@ export default class FWorkshopFileSizes extends Feature<CMyWorkshop> {
     private _failed: number = 0;
     private _totalSize: number = 0;
     private _total: number = 0;
+    private textCtn: HTMLElement|null = null;
 
     override checkPrerequisites(): boolean {
         // Check if the user is signed in, viewing own profile, and has subscribed to at least one item
@@ -72,7 +73,12 @@ export default class FWorkshopFileSizes extends Feature<CMyWorkshop> {
         this._failed = 0;
         this._totalSize = 0;
 
-        this._updateWaitDialog();
+        await SteamFacade.showBlockingWaitDialog(
+            L(__calcWorkshopSize_calcSize),
+            `<div id="as_loading_text_ctn">${this.getStatusString()}</div>`
+        );
+
+        this.textCtn = document.querySelector("#as_loading_text_ctn")!;
 
         const parser = new DOMParser();
         const url = new URL(window.location.origin + window.location.pathname);
@@ -102,7 +108,7 @@ export default class FWorkshopFileSizes extends Feature<CMyWorkshop> {
                     this._failed++;
                     console.error(err);
                 } finally {
-                    this._updateWaitDialog();
+                    HTML.inner(this.textCtn, this.getStatusString());
                 }
             }
         }
@@ -123,8 +129,7 @@ export default class FWorkshopFileSizes extends Feature<CMyWorkshop> {
         this._addFileSizes(); // Add file sizes now that data has been fetched
     }
 
-    _updateWaitDialog(): void {
-
+    private getStatusString(): string {
         let statusString = L(__calcWorkshopSize_calcLoading, {
             "i": this._completed,
             "count": this._total
@@ -135,15 +140,7 @@ export default class FWorkshopFileSizes extends Feature<CMyWorkshop> {
             statusString += L(__workshop_failed, {"n": this._failed});
         }
 
-        const container = document.querySelector("#as_loading_text_ctn");
-        if (container) {
-            HTML.inner(container, statusString);
-        } else {
-            SteamFacade.showBlockingWaitDialog(
-                L(__calcWorkshopSize_calcSize),
-                `<div id="as_loading_text_ctn">${statusString}</div>`
-            );
-        }
+        return statusString;
     }
 
     _getFileSizeStr(size: number): string {

--- a/src/js/Content/Features/Community/Recommended/FReviewSort.ts
+++ b/src/js/Content/Features/Community/Recommended/FReviewSort.ts
@@ -183,7 +183,7 @@ export default class FReviewSort extends Feature<CRecommended> {
     }
 
     async _getReviews(): Promise<void> {
-        SteamFacade.showBlockingWaitDialog(L(__processing), L(__wait));
+        await SteamFacade.showBlockingWaitDialog(L(__processing), L(__wait));
 
         try {
             this._reviews = await SteamCommunityApiFacade.getReviews(this._path, this._pages);

--- a/src/js/Content/Modules/Facades/SteamFacade.ts
+++ b/src/js/Content/Modules/Facades/SteamFacade.ts
@@ -41,8 +41,8 @@ export default class SteamFacade {
         ]);
     }
 
-    static showBlockingWaitDialog(strTitle: string, strDescription: string): void {
-        Messenger.call(MessageHandler.SteamFacade, "showBlockingWaitDialog", [
+    static showBlockingWaitDialog(strTitle: string, strDescription: string): Promise<void> {
+        return Messenger.get(MessageHandler.SteamFacade, "showBlockingWaitDialog", [
             strTitle, strDescription
         ]);
     }

--- a/src/scriptlets/SteamScriptlet.js
+++ b/src/scriptlets/SteamScriptlet.js
@@ -35,7 +35,10 @@
         }
 
         static showBlockingWaitDialog(strTitle, strDescription) {
-            return ShowBlockingWaitDialog(strTitle, strDescription);
+            return new Promise(resolve => {
+                ShowBlockingWaitDialog(strTitle, strDescription);
+                resolve();
+            });
         }
 
         static dismissActiveModal() {
@@ -109,12 +112,21 @@
             return;
         }
 
-        const result = Steam[action](...params);
+        let result = Steam[action](...params);
 
         if (id) {
+
+            if (result instanceof Promise) {
+                result = await result;
+            }
+
+            if (typeof result === "object") {
+                // Remove un-structuredClone-able properties, otherwise `detail` will be `null`
+                result = JSON.parse(JSON.stringify(result));
+            }
+
             document.dispatchEvent(new CustomEvent(id, {
-                // Remove un-structuredClone-able properties, otherwise this will return `null`
-                detail: JSON.parse(JSON.stringify(await result))
+                detail: result
             }));
         }
     });


### PR DESCRIPTION
Similar to #1944, in that the old way of inserting scripts was synchronous, so after inserting the wait dialog we could immediately query the text node from the DOM. Fixed it by making `SteamFacade.showBlockingWaitDialog` return a promise, and refactored all usages so the logic is hopefully clearer.

Fixes #1952.
Also fixed a bug where if you dismiss the confirm dialog we would still proceed to clear the wishlist.