### PR TITLE
Avoid forced sync calls on every page load

### DIFF
--- a/src/js/Background/Modules/IsThereAnyDeal/ITADApi.ts
+++ b/src/js/Background/Modules/IsThereAnyDeal/ITADApi.ts
@@ -324,9 +324,9 @@ export default class ITADApi extends Api implements MessageHandlerInterface {
     }
 
     private async sync(): Promise<void> {
-        await this.exportToItad(true);
-        await this.importWaitlist(true);
-        await this.importCollection(true);
+        await this.exportToItad(false);
+        await this.importWaitlist(false);
+        await this.importCollection(false);
     }
 
     private async inWaitlist(storeIds: string[]): Promise<TInWaitlistResponse> {


### PR DESCRIPTION
Currently, when the periodic import of Library or Waitlist is enabled, a sync call with ITAD is forced on every page load.  This ends up having a noticeable performance effect on Steam given a larger wishlist and/or collection size.  This PR switches off the `force` boolean such that the sync calls will instead check the expiry timers set after a previous sync call.

Fixes #1976 