### PR TITLE
Remove runtime `Object.freeze` calls

### DIFF
--- a/src/js/Core/Currencies.ts
+++ b/src/js/Core/Currencies.ts
@@ -21,7 +21,7 @@ export interface TCurrency {
     }
 }
 
-export default Object.freeze(<Array<TCurrency>>[
+export default <ReadonlyArray<TCurrency>>[
     { "id": 1, "abbr": "USD", "symbol": "$", "hint": "United States Dollars", "multiplier": 100, "unit": 1, "format": { "places": 2, "hidePlacesWhenZero": false, "symbolFormat": "$", "thousand": ",", "decimal": ".", "right": false } },
     { "id": 2, "abbr": "GBP", "symbol": "£", "hint": "British Pound", "multiplier": 100, "unit": 1, "format": { "places": 2, "hidePlacesWhenZero": false, "symbolFormat": "£", "thousand": ",", "decimal": ".", "right": false } },
     { "id": 3, "abbr": "EUR", "symbol": "€", "hint": "European Union Euro", "multiplier": 100, "unit": 1, "format": { "places": 2, "hidePlacesWhenZero": false, "symbolFormat": "€", "thousand": " ", "decimal": ",", "right": true } },
@@ -61,4 +61,4 @@ export default Object.freeze(<Array<TCurrency>>[
     { "id": 39, "abbr": "QAR", "symbol": "QR", "hint": "Qatari Riyal", "multiplier": 100, "unit": 1, "format": { "places": 2, "hidePlacesWhenZero": false, "symbolFormat": " QR", "thousand": ",", "decimal": ".", "right": true } },
     { "id": 40, "abbr": "CRC", "symbol": "₡", "hint": "Costa Rican Colón", "multiplier": 100, "unit": 500, "format": { "places": 2, "hidePlacesWhenZero": false, "symbolFormat": "₡", "thousand": ".", "decimal": ",", "right": false } },
     { "id": 41, "abbr": "UYU", "symbol": "$U", "hint": "Uruguayan Peso", "multiplier": 100, "unit": 100, "format": { "places": 0, "hidePlacesWhenZero": true, "symbolFormat": "$U", "thousand": ",", "decimal": ".", "right": false } }
-]);
+];

--- a/src/js/Core/Errors/Errors.ts
+++ b/src/js/Core/Errors/Errors.ts
@@ -31,9 +31,9 @@ class FeatureDependencyError extends Error {
     }
 }
 
-export default Object.freeze({
+export default {
     LoginError,
     ServerOutageError,
     HTTPError,
     FeatureDependencyError
-});
+};

--- a/src/js/Options/Data/Settings.ts
+++ b/src/js/Options/Data/Settings.ts
@@ -3,7 +3,7 @@ import type {SettingsSchema} from "./_types";
 import type {SchemaKeys, SchemaValue, StorageInterface} from "@Core/Storage/Storage";
 import {SyncedStorage} from "@Core/Storage/SyncedStorage";
 
-export const DefaultSettings: SettingsSchema = Object.freeze({
+export const DefaultSettings: Readonly<SettingsSchema> = {
     "language": "english",
 
     "version": Info.version,
@@ -185,7 +185,7 @@ export const DefaultSettings: SettingsSchema = Object.freeze({
     "context_steamdb": false,
     "context_steamdb_instant": false,
     "context_steam_keys": false,
-});
+};
 
 
 type TListener = () => void;


### PR DESCRIPTION
I think relying on compile-time `readonly` should be enough?