### PR TITLE
Refactor getting web api token

### DIFF
--- a/src/js/Content/Features/Community/Inventory/FEquipProfileItems.ts
+++ b/src/js/Content/Features/Community/Inventory/FEquipProfileItems.ts
@@ -74,7 +74,7 @@ export default class FEquipProfileItems extends Feature<CInventory> {
             }
 
             try {
-                const token = await User.accessToken;
+                const token = await User.getWebApiToken();
                 await RequestData.post(`https://api.steampowered.com${apiPath}?access_token=${token}`, data, {"credentials": "omit"});
 
                 btn.classList.add("btn_disabled");

--- a/src/js/Content/Features/Community/ProfileStats/FShowHiddenAchievements.ts
+++ b/src/js/Content/Features/Community/ProfileStats/FShowHiddenAchievements.ts
@@ -79,7 +79,7 @@ export default class FShowHiddenAchievements extends Feature<CProfileStats> {
 
         const params = new URLSearchParams();
         params.set("format", "json");
-        params.set("access_token", await User.accessToken);
+        params.set("access_token", await User.getWebApiToken());
         params.set("appid", String(appid));
         params.set("language", Language.getCurrentSteamLanguage() ?? "en");
         params.set("x_requested_with", "AugmentedSteam");

--- a/src/js/Content/Modules/SteamApi.ts
+++ b/src/js/Content/Modules/SteamApi.ts
@@ -20,7 +20,7 @@ export default class SteamApi {
         };
 
         try {
-            const token = await User.accessToken;
+            const token = await User.getWebApiToken();
             const steamId = User.steamId;
 
             const response = await RequestData.post(

--- a/src/js/Content/Modules/User.ts
+++ b/src/js/Content/Modules/User.ts
@@ -16,7 +16,7 @@ export default class User {
     private static _profilePath: string;
 
     private static _sessionId: string|null;
-    private static _accessToken: string;
+    private static _webApiToken: string;
 
     static async promise(): Promise<void> {
         if (!this._promise) {
@@ -133,29 +133,27 @@ export default class User {
     }
 
     /*
-     * Retrieve user access token to use in new style WebAPI calls (Services)
+     * Fetch the user's web api token to use in new style WebAPI calls (Services)
      * https://github.com/Revadike/UnofficialSteamWebAPI/wiki/Get-Points-Summary-Config
+     * Works on both store and community, but only returns the store token
      */
-    static get accessToken(): Promise<string> {
-        if (this._accessToken) {
-            return Promise.resolve(this._accessToken);
-        }
-
-        // This endpoint works on both store and community
-        return (async (): Promise<string> => {
+    static async getWebApiToken(): Promise<string> {
+        if (!this._webApiToken) {
             const response = await RequestData.getJson<{
                 success?: boolean,
                 data?: {
                     webapi_token?: string
                 }
             }>(`${window.location.origin}/pointssummary/ajaxgetasyncconfig`);
+
             if (!response.success || !response.data?.webapi_token) {
                 throw new Error("Failed to get webapi token");
             }
 
-            this._accessToken = response.data.webapi_token;
-            return this._accessToken;
-        })();
+            this._webApiToken = response.data.webapi_token;
+        }
+
+        return this._webApiToken;
     }
 }
 


### PR DESCRIPTION
Reworks the `User.accessToken` getter to `User.getWebApiToken()` so it's more descriptive and doesn't collide with ITAD's `AccessToken` class.