### PR TITLE
Don't add DLC row margin when app has no paid DLCs

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1658,7 +1658,7 @@ video.highlight_movie:hover + .html5_video_overlay {
   display: none; /* hide dlc flag due to checkboxes (if highlighting is disabled) */
 }
 
-.game_area_dlc_name {
+#es_dlc_option_panel + .game_area_dlc_list .game_area_dlc_name {
   margin-left: 23px; /* move title out of the way */
 }
 


### PR DESCRIPTION
i.e. when the DLC checkboxes feature is not applied.
Example store page `https://store.steampowered.com/app/1113560/NieR_Replicant_ver122474487139/`