### PR TITLE
Refactor extra links

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1368,13 +1368,6 @@ video.highlight_movie:hover + .html5_video_overlay {
  * App pages
  * Common/FExtraLinks
  **************************************/
-.es_app_btn {
-  display: block !important;
-  margin-bottom: 6px;
-}
-.es_app_btn .ico16 {
-  margin-right: 12px !important;
-}
 .es_extralinks_ctn .es_app_btn:last-of-type {
   margin-bottom: 0px;
 }
@@ -2521,47 +2514,6 @@ label.es_dlc_label > input:checked::after {
   background-color: #b31414;
 }
 
-.steamdb_ico i {
-  background-image: url("extension://img/steamdb_store.png");
-}
-.steamdb_ico:hover i {
-  background-image: url("extension://img/steamdb_store_black.png");
-}
-
-.itad_ico i {
-  background-image: url("extension://img/itad_small.png");
-}
-.itad_ico:hover i {
-  background-image: url("extension://img/itad_small_black.png");
-}
-
-.bartervg_ico i {
-  background-image: url("extension://img/bartervg.png");
-}
-
-.as_youtube_btn i {
-  background-image: url("extension://img/icon-youtube.png");
-}
-
-.twitch_btn i {
-  background-image: url("extension://img/icon-twitch.png");
-}
-
-.pcgw_btn i {
-  background-image: url("extension://img/pcgw.png");
-}
-
-.completionistme_btn i {
-  background-image: url("extension://img/icon-completionistme.png");
-}
-
-.protondb_btn i {
-  background-image: url("extension://img/icon-protondb.png"); /* //www.protondb.com/images/protondb-logo.svg */
-}
-
-.cardexchange_btn i {
-  background-image: url("extension://img/steamcardexchange.png");
-}
 
 .es_slider_toggle i,
 .es_screenshot_fullscreen_toggle i {

--- a/src/js/Content/Features/Store/App/CApp.ts
+++ b/src/js/Content/Features/Store/App/CApp.ts
@@ -39,6 +39,7 @@ import FUserNotes from "./FUserNotes.js";
 import FWidescreenCertification from "./FWidescreenCertification";
 import {ContextType} from "@Content/Modules/Context/ContextType";
 import FExtraLinksApp from "@Content/Features/Store/Common/FExtraLinksApp";
+import FExtraLinksAppError from "@Content/Features/Store/Common/FExtraLinksAppError";
 import CStoreBase from "@Content/Features/Store/Common/CStoreBase";
 import AugmentedSteamApiFacade from "@Content/Modules/Facades/AugmentedSteamApiFacade";
 import type {TStorePageData} from "@Background/Modules/AugmentedSteam/_types";
@@ -47,9 +48,8 @@ import FHighlightTitle from "@Content/Features/Store/App/FHighlightTitle";
 
 export default class CApp extends CStoreBase {
 
-    public readonly isErrorPage: boolean = false;
-    public readonly storeid: string;
     public readonly appid: number;
+    public readonly storeid: string;
     public readonly communityAppid: number = 0;
     public readonly appName: string = "";
 
@@ -68,16 +68,12 @@ export default class CApp extends CStoreBase {
 
     constructor() {
 
-        let isErrorPage = false;
-
-        // Only add extra links if there's an error message (e.g. region-locked, age-gated)
-        if (document.getElementById("error_box") !== null) {
-            isErrorPage = true;
-        }
+        // Check if there's an error message (e.g. region-locked, age-gated)
+        const isErrorPage = document.getElementById("error_box") !== null;
 
         super(ContextType.APP, isErrorPage
             ? [
-                FExtraLinksApp
+                FExtraLinksAppError
             ] : [
                 FReplaceDevPubLinks,
                 FForceMP4,
@@ -122,11 +118,10 @@ export default class CApp extends CStoreBase {
                 FHighlightTitle
             ]);
 
-        this.isErrorPage = isErrorPage;
         this.appid = AppId.fromUrl(window.location.host + window.location.pathname)!;
         this.storeid = `app/${this.appid}`;
 
-        if (this.isErrorPage) {
+        if (isErrorPage) {
             return;
         }
 

--- a/src/js/Content/Features/Store/Common/ExtraLinks/ExtraLink.svelte
+++ b/src/js/Content/Features/Store/Common/ExtraLinks/ExtraLink.svelte
@@ -15,3 +15,48 @@
         <slot></slot>
     </span>
 </a>
+
+
+<style>
+    .es_app_btn {
+        display: block !important;
+        margin-bottom: 6px;
+    }
+    .es_app_btn .ico16 {
+        margin-right: 12px !important;
+    }
+
+    .steamdb_ico i {
+        background-image: url("extension://img/steamdb_store.png");
+    }
+    .steamdb_ico:hover i {
+        background-image: url("extension://img/steamdb_store_black.png");
+    }
+    .itad_ico i {
+        background-image: url("extension://img/itad_small.png");
+    }
+    .itad_ico:hover i {
+        background-image: url("extension://img/itad_small_black.png");
+    }
+    .bartervg_ico i {
+        background-image: url("extension://img/bartervg.png");
+    }
+    .as_youtube_btn i {
+        background-image: url("extension://img/icon-youtube.png");
+    }
+    .twitch_btn i {
+        background-image: url("extension://img/icon-twitch.png");
+    }
+    .pcgw_btn i {
+        background-image: url("extension://img/pcgw.png");
+    }
+    .completionistme_btn i {
+        background-image: url("extension://img/icon-completionistme.png");
+    }
+    .protondb_btn i {
+        background-image: url("extension://img/icon-protondb.png");
+    }
+    .cardexchange_btn i {
+        background-image: url("extension://img/steamcardexchange.png");
+    }
+</style>

--- a/src/js/Content/Features/Store/Common/FExtraLinksApp.ts
+++ b/src/js/Content/Features/Store/Common/FExtraLinksApp.ts
@@ -1,70 +1,29 @@
 import Feature from "@Content/Modules/Context/Feature";
-import HTML from "@Core/Html/Html";
-import {L} from "@Core/Localization/Localization";
 import StringUtils from "@Core/Utils/StringUtils";
-import {__communityHub} from "@Strings/_strings";
 import AppLinks from "@Content/Features/Store/Common/ExtraLinks/AppLinks.svelte";
 import type CApp from "@Content/Features/Store/App/CApp";
 
 export default class FExtraLinksApp extends Feature<CApp> {
 
-    private _node: HTMLElement|null = null;
+    // Even if the user disabled extra links, the position of the share/embed links is changed
+    override apply(): void {
 
-    override checkPrerequisites(): boolean {
-
-        this._node = document.querySelector<HTMLElement>(
-            this.context.isErrorPage
-                ? "#error_box"
-                : "#shareEmbedRow"
-        );
-
-        if (!this._node) {
-            console.warn("Couldn't find element to insert extra links");
-            return false;
+        const target = document.querySelector("#shareEmbedRow");
+        if (!target) {
+            throw new Error("Node not found");
         }
 
-        // Even if the user doesn't want to see any extra links, the position of the share/embed links is changed
-        return true;
-    }
-
-    apply() {
-        const node = this._node!;
-
-        if (this.context.isErrorPage) {
-
-            // Add a Community Hub button to roughly where it normally is
-            HTML.beforeBegin("h2.pageheader",
-                `<div class="es_apphub_OtherSiteInfo">
-                    <a class="btnv6_blue_hoverfade btn_medium" href="//steamcommunity.com/app/${this.context.appid}/">
-                        <span>${L(__communityHub)}</span>
-                    </a>
-                </div>`);
+        // Move share/embed links to the top of the right column
+        const sideDetails = document.querySelector(".es_side_details_wrap");
+        if (sideDetails) {
+            sideDetails.insertAdjacentElement("afterend", target);
         } else {
-
-            // Move share/embed links to the top of the right column
-            const sideDetails = document.querySelector(".es_side_details_wrap");
-            if (sideDetails) {
-                sideDetails.insertAdjacentElement("afterend", node);
-            } else {
-                document.querySelector("div.rightcol.game_meta_data")!.insertAdjacentElement("afterbegin", node);
-            }
-        }
-
-        let target: HTMLElement;
-        let anchor: HTMLElement|undefined = undefined;
-
-        if (this.context.isErrorPage) {
-            target = document.createElement("div");
-            target.classList.add("es_extralinks_ctn");
-            node.insertAdjacentElement("afterend", target);
-        } else {
-            target = node;
-            anchor = (node.firstElementChild ?? undefined) as HTMLElement|undefined;
+            document.querySelector("div.rightcol.game_meta_data")!.insertAdjacentElement("afterbegin", target);
         }
 
         (new AppLinks({
             target,
-            anchor,
+            anchor: target.firstElementChild!,
             props: {
                 appid: this.context.appid,
                 communityAppid: this.context.communityAppid,

--- a/src/js/Content/Features/Store/Common/FExtraLinksAppError.ts
+++ b/src/js/Content/Features/Store/Common/FExtraLinksAppError.ts
@@ -1,0 +1,48 @@
+import Feature from "@Content/Modules/Context/Feature";
+import HTML from "@Core/Html/Html";
+import {L} from "@Core/Localization/Localization";
+import {__communityHub} from "@Strings/_strings";
+import AppLinks from "@Content/Features/Store/Common/ExtraLinks/AppLinks.svelte";
+import type CApp from "@Content/Features/Store/App/CApp";
+import Settings from "@Options/Data/Settings";
+
+export default class FExtraLinksAppError extends Feature<CApp> {
+
+    override apply(): void {
+
+        // Add a Community Hub button to roughly where it normally is
+        HTML.beforeBegin("h2.pageheader",
+            `<div class="es_apphub_OtherSiteInfo">
+                <a class="btnv6_blue_hoverfade btn_medium" href="//steamcommunity.com/app/${this.context.appid}/">
+                    <span>${L(__communityHub)}</span>
+                </a>
+            </div>`);
+
+        if (!this.hasExtraLinksEnabled()) {
+            return;
+        }
+
+        const target = document.createElement("div");
+        target.classList.add("es_extralinks_ctn");
+        document.querySelector("#error_box")!.insertAdjacentElement("afterend", target);
+
+        (new AppLinks({
+            target,
+            props: {
+                appid: this.context.appid,
+                communityAppid: this.context.appid,
+            }
+        }));
+    }
+
+    private hasExtraLinksEnabled(): boolean {
+        return Settings.showitadlinks
+            || Settings.showsteamdb
+            || Settings.showbartervg
+            || Settings.showsteamcardexchange
+            || Settings.showprotondb
+            || Settings.showcompletionistme
+            || Settings.showpcgw
+            || Settings.app_custom_link.some(link => link.enabled);
+    }
+}

--- a/src/js/Content/Features/Store/Common/FExtraLinksCommon.ts
+++ b/src/js/Content/Features/Store/Common/FExtraLinksCommon.ts
@@ -7,42 +7,30 @@ import type CSub from "@Content/Features/Store/Sub/CSub";
 
 export default class FExtraLinksCommon extends Feature<CSub|CBundle> {
 
-    // @ts-ignore
-    private _type: "sub"|"bundle";
-    // @ts-ignore
-    private _gameid: number;
-    private _node: HTMLElement|null = null;
+    override apply(): void {
 
-    override checkPrerequisites(): boolean {
+        let type: "sub"|"bundle";
+        let gameid: number;
+        let target: HTMLElement|null = null;
+
         if (this.context.type === ContextType.SUB) {
-            this._type = "sub";
-            this._gameid = (<CSub>(this.context)).subid;
-            this._node = (document.querySelector<HTMLElement>(".share")?.parentNode ?? null) as HTMLElement|null;
-        } else if (this.context.type === ContextType.BUNDLE) {
-            this._type = "bundle";
-            this._gameid = (<CBundle>(this.context)).bundleid;
-            this._node = document.querySelector<HTMLElement>(".share, .rightcol .game_details");
+            type = "sub";
+            gameid = (<CSub>(this.context)).subid;
+            target = document.querySelector(".share")?.parentElement ?? null;
+        } else {
+            type = "bundle";
+            gameid = (<CBundle>(this.context)).bundleid;
+            target = document.querySelector(".share, .rightcol .game_details");
         }
 
-        if (!this._node) {
-            console.warn("Couldn't find element to insert extra links");
+        if (!target) {
+            throw new Error("Node not found");
         }
 
-        return this._node !== null && (
-                // Preferences for links shown on all pages
-                (Settings.showbartervg || Settings.showsteamdb || Settings.showitadlinks
-            )
-        );
-    }
-
-    apply() {
         (new CommonLinks({
-            target: this._node!,
-            anchor: this._node!.firstElementChild ?? undefined,
-            props: {
-                type: this._type,
-                gameid: this._gameid
-            }
+            target,
+            anchor: target.firstElementChild!,
+            props: {type, gameid}
         }));
     }
 }


### PR DESCRIPTION
1. Remove `checkPrerequisites()` calls from extra link features, and just throw if node not found
2. Split out logic for extra links on app error pages
3. Fix app error pages rendering an empty div when all extra links are disabled