### PR TITLE
Fix space between prices and the purchase container

### DIFF
--- a/src/js/Content/Modules/Prices/PriceOverview.svelte
+++ b/src/js/Content/Modules/Prices/PriceOverview.svelte
@@ -87,6 +87,10 @@
 
 
 <style>
+    /* Fix space between prices and the purchase container when an "ADVANCED ACCESS" banner is present */
+    .itad-pricing + :global(.game_area_purchase_game_wrapper .advanced_access_header_wrapper) {
+        margin-top: -7px;
+    }
     .itad-pricing {
         padding: 5px 5px 5px 42px;
         height: auto !important;


### PR DESCRIPTION
This was meant to be part of #1912. I did test this back then, but I don't know of any game that offers this now 😅

The styles on Steam's side haven't changed since they were added so this should still work
https://github.com/SteamDatabase/SteamTracking/blame/1e625e7d29e850cf9d9e9b3fc33ba42a09d765cc/store.steampowered.com/public/css/v6/game.css#L893