### PR TITLE
FRegionalPricing: refactor

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1229,46 +1229,26 @@ video.highlight_movie:hover + .html5_video_overlay {
 }
 .es_regional_icon {
   padding-left: 23px !important;
+  background-image: url("extension://img/flags/world.png") !important;
   background-repeat: no-repeat !important;
   background-position: 8px 8px !important;
 }
 .es_regional_icon.price {
   padding-left: 30px !important;
 }
-.es_regional_container {
-  z-index: 10;
-  background: linear-gradient(to bottom, #33425a 5%, #282f3d 100%);
-  padding: 7px 8px;
-  box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.8);
-  border: 1px solid black;
-  margin-top: -25px;
-  text-align: left;
-}
-.es_regional_container > .es_regional_arrow {
-  border-top: 9px solid transparent;
-  border-bottom: 9px solid transparent;
-  border-left: 8px solid #313f56;
-  position: absolute;
-  top: 12px;
-  right: -8px;
-  width: 0;
-  height: 0;
-}
+
 /**
- * Raise the purchase container's z-index on hover so the popup shows on top of subsequent purchase containers.
- * Must be lower than the default z-index for CModal (1000) to avoid the dialogs glitching out when clicking inside the purchase container.
- * Set to 501 in order to prevent it colliding with subscription dropdown (see issue 1969)
+ * Raise the popup's z-index so it shows on top of subsequent purchase containers.
+ * Set to higher than 500 (see #1969)
  */
-.es_regional_prices.game_area_purchase_game:hover {
-  z-index: 501;
-}
-.es_regional_prices:not(.es_regional_always) .es_regional_container {
+body > .es_regional_container {
+  z-index: 1000;
   display: none;
   position: absolute;
   pointer-events: none;
-  top: 20px;
-  right: 100%;
+  height: min-content;
 }
+
 .es_regional_always::after {
   content: "";
   display: block;
@@ -1280,73 +1260,6 @@ video.highlight_movie:hover + .html5_video_overlay {
   float: right;
   margin-bottom: 5px;
   margin-top: auto;
-}
-.es_regional_onmouse:hover .es_regional_container {
-  display: block !important;
-}
-
-/** Regional price comparison popup */
-.es-regprice {
-  display: flex;
-  align-items: baseline;
-  font-size: 14px;
-  white-space: nowrap;
-}
-.es-regprice__converted {
-  font-size: 12px;
-  text-align: right;
-  flex-grow: 1;
-  min-width: 60px;
-  margin-left: 5px
-}
-.es-regprice__perc {
-  font-size: 12px;
-  margin-left: 5px;
-  width: 60px;
-  text-align: right;
-}
-.es-regprice__perc::after {
-  content: "";
-  width: 0;
-  height: 0;
-  margin-left: 4px;
-  margin-bottom: 2px;
-  position: relative;
-  display: inline-block;
-  border-color: transparent;
-  border-style: solid;
-}
-.es-regprice__perc--higher {
-  color: #ff1717;
-}
-.es-regprice__perc--equal {
-  color: #e5e500;
-}
-.es-regprice__perc--lower {
-  color: #60ad0a;
-}
-.es-regprice__perc--higher::after {
-  border-width: 0 5px 5px 5px;
-  border-bottom-color: #ff1717;
-}
-.es-regprice__perc--equal::after {
-  width: 6px;
-  content: "=";
-}
-.es-regprice__perc--lower::after {
-  border-width: 5px 5px 0 5px;
-  border-top-color: #60ad0a;
-}
-.es-regprice__none {
-  font-size: 12px;
-}
-
-/**
- * https://github.com/IsThereAnyDeal/AugmentedSteam/issues/389
- * Fix unclickable dropdowns
- */
-.ds_options_tooltip {
-  z-index: 99999 !important;
 }
 
 /***************************************
@@ -2492,10 +2405,6 @@ label.es_dlc_label > input:checked::after {
 
 .es_screenshot_open_btn i {
   background-image: url('extension://img/screenshot_open.png');
-}
-
-.es_regional_icon {
-  background-image: url("extension://img/flags/world.png") !important;
 }
 
 .itad-pricing {

--- a/src/js/Content/Features/Store/Common/FRegionalPricing.svelte
+++ b/src/js/Content/Features/Store/Common/FRegionalPricing.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+    import Settings from "@Options/Data/Settings";
+    import Price from "@Content/Modules/Currency/Price";
+    import CurrencyManager from "@Content/Modules/Currency/CurrencyManager";
+    import User from "@Content/Modules/User";
+    import {L} from "@Core/Localization/Localization";
+    import {__regionUnavailable} from "@Strings/_strings";
+    import type {PackageDetailsPrice} from "./FRegionalPricing";
+
+    export let countries: string[];
+    export let prices: Record<string, PackageDetailsPrice>;
+    export let errors: Set<string>;
+    export let priceNode: Element|null = null;
+
+    let priceLocal: Price|null = null;
+    try {
+        const apiPrice: PackageDetailsPrice = prices[User.storeCountry.toLowerCase()]!;
+        priceLocal = (new Price(apiPrice.final / 100, apiPrice.currency))
+            .inCurrency(CurrencyManager.customCurrency);
+    } catch (err) {
+        handleError(err);
+    }
+
+    function getPriceUser(priceRegion: Price, country: string): Price|null {
+        try {
+            return priceRegion.inCurrency(CurrencyManager.customCurrency);
+        } catch (err) {
+            handleError(err, country);
+            return null;
+        }
+    }
+
+    function handleError(e: any, country?: string): void {
+        const message = country
+            ? `Can't show converted price and relative price differences for country code ${country.toUpperCase()}`
+            : "Can't show relative price differences to any other currencies";
+
+        if (!errors.has(message)) {
+            errors.add(message);
+
+            console.group("Regional pricing");
+            console.warn(message);
+            console.error(e);
+            console.groupEnd();
+        }
+    }
+
+    let container: HTMLElement;
+
+    if (Settings.showregionalprice === "mouse") {
+
+        priceNode!.addEventListener("mouseenter", () => {
+            const rects = priceNode!.getBoundingClientRect();
+            container.style.display = "block";
+            container.style.top = `${rects.top + window.scrollY - 5}px`;
+            container.style.left = `${rects.left - container.getBoundingClientRect().width}px`;
+        });
+
+        priceNode!.addEventListener("mouseleave", () => {
+            container.style.display = "none";
+        });
+    }
+</script>
+
+
+<div class="es_regional_container" bind:this={container}>
+    {#if Settings.showregionalprice === "mouse"}
+        <div class="es_regional_arrow"></div>
+    {/if}
+    {#each countries as country}
+        {@const apiPrice = prices[country]}
+        <div class="es-regprice es-flag es-flag--{country}">
+            {#if apiPrice}
+                {@const priceRegion = new Price(apiPrice.final / 100, apiPrice.currency)}
+                {@const priceUser = getPriceUser(priceRegion, country)}
+                {priceRegion.toString()}
+                    {#if priceLocal && priceUser}
+                        {@const percentage = Number((((priceUser.value / priceLocal.value) * 100) - 100).toFixed(2))}
+                        {@const indicator = percentage > 0 ? "higher" : percentage < 0 ? "lower" : "equal"}
+                        <span class="es-regprice__converted">{priceUser.toString()}</span>
+                        <span class="es-regprice__perc es-regprice__perc--{indicator}">{Math.abs(percentage)}%</span>
+                    {/if}
+            {:else}
+                <span class="es-regprice__none">{L(__regionUnavailable)}</span>
+            {/if}
+        </div>
+    {/each}
+</div>
+
+
+<style>
+    .es_regional_container {
+        background: linear-gradient(to bottom, #33425a 5%, #282f3d 100%);
+        padding: 7px 8px;
+        box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.8);
+        border: 1px solid black;
+        text-align: left;
+    }
+    .es_regional_arrow {
+        border-top: 9px solid transparent;
+        border-bottom: 9px solid transparent;
+        border-left: 8px solid #313f56;
+        position: absolute;
+        top: 12px;
+        right: -8px;
+        width: 0;
+        height: 0;
+    }
+
+    .es-regprice {
+        display: flex;
+        align-items: baseline;
+        font-size: 14px;
+        white-space: nowrap;
+    }
+    .es-regprice__converted {
+        font-size: 12px;
+        text-align: right;
+        flex-grow: 1;
+        min-width: 60px;
+        margin-left: 5px
+    }
+    .es-regprice__perc {
+        font-size: 12px;
+        margin-left: 5px;
+        width: 60px;
+        text-align: right;
+    }
+    .es-regprice__perc::after {
+        content: "";
+        width: 0;
+        height: 0;
+        margin-left: 4px;
+        margin-bottom: 2px;
+        position: relative;
+        display: inline-block;
+        border-color: transparent;
+        border-style: solid;
+    }
+    .es-regprice__perc--higher {
+        color: #ff1717;
+    }
+    .es-regprice__perc--equal {
+        color: #e5e500;
+    }
+    .es-regprice__perc--lower {
+        color: #60ad0a;
+    }
+    .es-regprice__perc--higher::after {
+        border-width: 0 5px 5px 5px;
+        border-bottom-color: #ff1717;
+    }
+    .es-regprice__perc--equal::after {
+        width: 6px;
+        content: "=";
+    }
+    .es-regprice__perc--lower::after {
+        border-width: 5px 5px 0 5px;
+        border-top-color: #60ad0a;
+    }
+    .es-regprice__none {
+        font-size: 12px;
+    }
+</style>

--- a/src/js/Content/Features/Store/Common/FRegionalPricing.ts
+++ b/src/js/Content/Features/Store/Common/FRegionalPricing.ts
@@ -1,15 +1,11 @@
-import {__regionUnavailable} from "@Strings/_strings";
+import self_ from "./FRegionalPricing.svelte";
 import type CSub from "@Content/Features/Store/Sub/CSub";
 import Feature from "@Content/Modules/Context/Feature";
 import User from "@Content/Modules/User";
 import RequestData from "@Content/Modules/RequestData";
-import Price from "@Content/Modules/Currency/Price";
-import CurrencyManager from "@Content/Modules/Currency/CurrencyManager";
-import HTML from "@Core/Html/Html";
-import {L} from "@Core/Localization/Localization";
 import Settings from "@Options/Data/Settings";
 
-interface PackageDetailsPrice {
+export interface PackageDetailsPrice {
     currency: string,
     initial: number,
     final: number,
@@ -28,9 +24,6 @@ interface PackageDetails {
 
 export default class FRegionalPricing extends Feature<CSub> {
 
-    // Store error messages to avoid duplicate console warnings
-    private _errors: Set<string> = new Set();
-
     override checkPrerequisites(): boolean {
         const countries = Settings.regional_countries;
         return countries && countries.length > 0 && Settings.showregionalprice !== "off";
@@ -38,7 +31,6 @@ export default class FRegionalPricing extends Feature<CSub> {
 
     override async apply(): Promise<void> {
 
-        const showRegionalPrice = Settings.showregionalprice;
         const countries = Settings.regional_countries;
         const localCountry = User.storeCountry.toLowerCase();
 
@@ -46,48 +38,27 @@ export default class FRegionalPricing extends Feature<CSub> {
             countries.push(localCountry);
         }
 
+        // Store errors to avoid duplicate console warnings
+        const errors = new Set<string>();
+
         for (const subid of this.context.getAllSubids()) {
-            const prices: {[P: string]: PackageDetailsPrice} = {};
+            const prices: Record<string, PackageDetailsPrice> = {};
 
             await Promise.all(countries.map(async country => {
                 const result = await RequestData.getJson<PackageDetails>(
                     `https://store.steampowered.com/api/packagedetails/?packageids=${subid}&cc=${country}`,
                     {"credentials": "omit"}
                 );
+                if (!result) { return; }
 
-                if (!result || !result[subid]) { return; }
+                const data = result[subid];
+                if (!data || !data.success || !data.data.price) { return; }
 
-                const data = result[subid]!;
-                if (!data.success || !data.data.price) { return; }
                 prices[country] = data.data.price;
             }));
 
-            const apiPrice = prices[User.storeCountry.toLowerCase()];
-
             // For paid titles that have F2P versions with their own subid (see #894)
-            if (typeof apiPrice === "undefined") { continue; }
-
-            let priceLocal;
-            try {
-                priceLocal = (new Price(apiPrice.final / 100, apiPrice.currency))
-                    .inCurrency(CurrencyManager.customCurrency);
-            } catch (e) {
-                this._handleError(e);
-            }
-
-            const pricingDiv = document.createElement("div");
-            pricingDiv.classList.add("es_regional_container");
-
-            if (showRegionalPrice === "mouse") {
-                HTML.afterBegin(pricingDiv, '<div class="es_regional_arrow"></div>');
-            }
-
-            for (const country of countries) {
-                if (!prices[country] || !priceLocal) {
-                    continue;
-                }
-                HTML.beforeEnd(pricingDiv, this._getCountryHTML(country, prices[country]!, priceLocal));
-            }
+            if (prices[localCountry] === undefined) { continue; }
 
             const node = document.querySelector(`input[name=subid][value="${subid}"]`)!
                 .closest(".game_area_purchase_game_wrapper, #game_area_purchase")!
@@ -96,70 +67,36 @@ export default class FRegionalPricing extends Feature<CSub> {
             const purchaseArea = node.closest(".game_area_purchase_game")!;
             purchaseArea.classList.add("es_regional_prices");
 
-            if (showRegionalPrice === "always") {
-                node.insertAdjacentElement("beforebegin", pricingDiv);
+            if (Settings.showregionalprice === "always") {
                 purchaseArea.classList.add("es_regional_always");
-            } else {
+
+                (new self_({
+                    target: node.parentElement!,
+                    anchor: node,
+                    props: {
+                        countries,
+                        prices,
+                        errors,
+                    }
+                }));
+            } else if (Settings.showregionalprice === "mouse") {
                 const priceNode = node.querySelector(".price, .discount_prices")!;
-                priceNode.insertAdjacentElement("beforeend", pricingDiv);
                 priceNode.classList.add("es_regional_onmouse");
 
                 if (!Settings.regional_hideworld) {
                     priceNode.classList.add("es_regional_icon");
                 }
+
+                (new self_({
+                    target: document.body,
+                    props: {
+                        countries,
+                        prices,
+                        errors,
+                        priceNode,
+                    }
+                }));
             }
-        }
-    }
-
-    private _getCountryHTML(country: string, apiPrice: PackageDetailsPrice, priceLocal: Price): string {
-        let html = "";
-
-        if (apiPrice) {
-            const priceRegion = new Price(apiPrice.final / 100, apiPrice.currency);
-            let priceUser;
-            try {
-                priceUser = priceRegion.inCurrency(CurrencyManager.customCurrency);
-            } catch (err) {
-                this._handleError(err, country);
-            }
-
-            html += `<div class="es-regprice es-flag es-flag--${country}">${priceRegion}`;
-
-            if (priceLocal && priceUser) {
-                let percentageIndicator = "equal";
-                let percentage = Number((((priceUser.value / priceLocal.value) * 100) - 100).toFixed(2));
-
-                if (percentage < 0) {
-                    percentage = Math.abs(percentage);
-                    percentageIndicator = "lower";
-                } else if (percentage > 0) {
-                    percentageIndicator = "higher";
-                }
-
-                html += `<span class="es-regprice__converted">${priceUser}</span>`;
-                html += `<span class="es-regprice__perc es-regprice__perc--${percentageIndicator}">${percentage}%</span>`;
-            }
-        } else {
-            html += `<div class="es-regprice es-flag es-flag--${country}">`;
-            html += `<span class="es-regprice__none">${L(__regionUnavailable)}</span>`;
-        }
-
-        html += "</div>";
-        return html;
-    }
-
-    private _handleError(e: any, country: string|undefined=undefined): void {
-        const message = country
-            ? `Can't show converted price and relative price differences for country code ${country.toUpperCase()}`
-            : "Can't show relative price differences to any other currencies";
-
-        if (!this._errors.has(message)) {
-            this._errors.add(message);
-
-            console.group("Regional pricing");
-            console.error(e);
-            console.warn(message);
-            console.groupEnd();
         }
     }
 }


### PR DESCRIPTION
Besides svelte-fying, reworked to calculating the regional prices container dynamically. This avoids messing around with the purchase container's z-index, and fixes a small glitch with the "advanced access" banner (its z-index is small, so hovering over the purchase container with regional prices set to "on mouse over" will cause weird overlaps).

Also restored the "Not available in this region" text when api price is missing.