### PR TITLE
CGroupHome: add a more reliable fallback to get group id; svelte-fy features

### DIFF
--- a/src/js/Content/Features/Community/GroupHome/CGroupHome.ts
+++ b/src/js/Content/Features/Community/GroupHome/CGroupHome.ts
@@ -5,26 +5,28 @@ import FGroupLinks from "@Content/Features/Community/GroupHome/FGroupLinks";
 
 export default class CGroupHome extends CCommunityBase {
 
-    // @ts-ignore
-    public readonly groupId: string;
+    public readonly groupId: string|null = null;
 
     constructor() {
+
         // Don't apply features if there's an error message (e.g. non-existent group)
-        if (document.getElementById("message") !== null) {
-            super(ContextType.GROUP_HOME);
+        const hasFeatures = document.getElementById("message") === null;
+
+        super(ContextType.GROUP_HOME, hasFeatures ? [
+            FFriendsInviteButton,
+            FGroupLinks,
+        ] : []);
+
+        if (!hasFeatures) {
             return;
         }
 
-        super(ContextType.GROUP_HOME, [
-            FFriendsInviteButton,
-            FGroupLinks,
-        ]);
-
-        const groupIdNode = document.querySelector<HTMLInputElement>("input[name=groupId], input[name=abuseID]");
-        if (!groupIdNode) {
-            throw new Error("Did not find groupId");
-        }
-
-        this.groupId = groupIdNode.value;
+        // Check `#leave_group_form` when logged in; fallback to the join chat button otherwise
+        this.groupId = document.querySelector<HTMLInputElement>("input[name=groupId]")?.value
+            ?? document.querySelector(".joinchat_bg")
+                ?.getAttribute("onclick")
+                ?.match(/OpenGroupChat\(\s*'(\d+)'/)
+                ?.[1]
+            ?? null;
     }
 }

--- a/src/js/Content/Features/Community/GroupHome/FFriendsInviteButton.svelte
+++ b/src/js/Content/Features/Community/GroupHome/FFriendsInviteButton.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+    import {__inviteFriends} from "@Strings/_strings";
+    import {L} from "@Core/Localization/Localization";
+
+    export let groupId: string;
+</script>
+
+
+<div class="grouppage_join_area">
+    <a class="btn_blue_white_innerfade btn_medium" href="https://steamcommunity.com/my/friends/?invitegid={groupId}">
+        <span><img src="//community.cloudflare.steamstatic.com/public/images/groups/icon_invitefriends.png" alt="Invite Icon">&nbsp; {L(__inviteFriends)}</span>
+    </a>
+</div>

--- a/src/js/Content/Features/Community/GroupHome/FFriendsInviteButton.ts
+++ b/src/js/Content/Features/Community/GroupHome/FFriendsInviteButton.ts
@@ -8,7 +8,9 @@ import HTML from "@Core/Html/Html";
 export default class FFriendsInviteButton extends Feature<CGroupHome> {
 
     override checkPrerequisites(): boolean {
-        return User.isSignedIn && document.querySelector(".grouppage_join_area") === null;
+        return User.isSignedIn
+            && this.context.groupId !== null
+            && document.querySelector(".grouppage_join_area") === null;
     }
 
     apply() {

--- a/src/js/Content/Features/Community/GroupHome/FFriendsInviteButton.ts
+++ b/src/js/Content/Features/Community/GroupHome/FFriendsInviteButton.ts
@@ -1,9 +1,7 @@
-import {__inviteFriends} from "@Strings/_strings";
-import {L} from "@Core/Localization/Localization";
+import self_ from "./FFriendsInviteButton.svelte";
 import Feature from "@Content/Modules/Context/Feature";
 import type CGroupHome from "@Content/Features/Community/GroupHome/CGroupHome";
 import User from "@Content/Modules/User";
-import HTML from "@Core/Html/Html";
 
 export default class FFriendsInviteButton extends Feature<CGroupHome> {
 
@@ -13,12 +11,18 @@ export default class FFriendsInviteButton extends Feature<CGroupHome> {
             && document.querySelector(".grouppage_join_area") === null;
     }
 
-    apply() {
-        HTML.afterEnd("#join_group_form",
-            `<div class="grouppage_join_area">
-                <a class="btn_blue_white_innerfade btn_medium" href="https://steamcommunity.com/my/friends/?invitegid=${this.context.groupId}">
-                    <span><img src="//community.cloudflare.steamstatic.com/public/images/groups/icon_invitefriends.png">&nbsp; ${L(__inviteFriends)}</span>
-                </a>
-            </div>`);
+    override apply(): void {
+
+        const node = document.querySelector("#join_group_form");
+        if (!node) {
+            throw new Error("Node not found");
+        }
+
+        (new self_({
+            target: node.parentElement!,
+            props: {
+                groupId: this.context.groupId!
+            }
+        }));
     }
 }

--- a/src/js/Content/Features/Community/GroupHome/FGroupLinks.ts
+++ b/src/js/Content/Features/Community/GroupHome/FGroupLinks.ts
@@ -5,23 +5,26 @@ import type CGroupHome from "@Content/Features/Community/GroupHome/CGroupHome";
 
 export default class FGroupLinks extends Feature<CGroupHome> {
 
-    override checkPrerequisites(): boolean | Promise<boolean> {
-        return Settings.group_steamgifts;
+    override checkPrerequisites(): boolean {
+        return Settings.group_steamgifts && this.context.groupId !== null;
     }
 
     override apply(): void {
 
-        const anchor = document.querySelector<HTMLElement>(".responsive_hidden > .rightbox")
+        const anchor = document.querySelector(".responsive_hidden > .rightbox")
             ?.parentElement
             ?.nextElementSibling;
-        if (anchor) {
-            (new self_({
-                target: anchor.parentElement!,
-                anchor: anchor as HTMLElement,
-                props: {
-                    groupId: this.context.groupId
-                }
-            }));
+
+        if (!anchor) {
+            throw new Error("Node not found");
         }
+
+        (new self_({
+            target: anchor.parentElement!,
+            anchor,
+            props: {
+                groupId: this.context.groupId!
+            }
+        }));
     }
 }


### PR DESCRIPTION
Group links should work when logged out, so revert to the old logic for getting group id prior to #1352.