### PR TITLE
Improve init methods

### DIFF
--- a/src/js/Background/Db/IndexedDB.ts
+++ b/src/js/Background/Db/IndexedDB.ts
@@ -21,7 +21,7 @@ export default class IndexedDB {
 
     public static db: IDBPDatabase<Schema>;
 
-    static async init() {
+    private static init(): Promise<void> {
         if (!this.promise) {
             this.promise = (async () => {
                 this.db = await openDB<Schema>("Augmented Steam", Info.db_version, {
@@ -43,11 +43,8 @@ export default class IndexedDB {
         return this.promise;
     }
 
-    static then(
-        onDone: (value: void) => PromiseLike<void>,
-        onCatch: (reason: any) => PromiseLike<never>
-    ): Promise<void> {
-        return IndexedDB.init().then(onDone, onCatch);
+    private static then(onDone: (value: void) => void|Promise<void>): Promise<void> {
+        return IndexedDB.init().then(onDone);
     }
 
     private static async cleanup() {

--- a/src/js/Background/Db/IndexedDB.ts
+++ b/src/js/Background/Db/IndexedDB.ts
@@ -21,7 +21,7 @@ export default class IndexedDB {
 
     public static db: IDBPDatabase<Schema>;
 
-    private static init(): Promise<void> {
+    static init(): Promise<void> {
         if (!this.promise) {
             this.promise = (async () => {
                 this.db = await openDB<Schema>("Augmented Steam", Info.db_version, {
@@ -41,10 +41,6 @@ export default class IndexedDB {
         }
 
         return this.promise;
-    }
-
-    private static then(onDone: (value: void) => void|Promise<void>): Promise<void> {
-        return IndexedDB.init().then(onDone);
     }
 
     private static async cleanup() {

--- a/src/js/Background/Modules/ContextMenu/ContextMenu.ts
+++ b/src/js/Background/Modules/ContextMenu/ContextMenu.ts
@@ -84,8 +84,8 @@ export default class ContextMenu {
     }
 
     static async build(): Promise<void> {
-        await SettingsStore;
-        await Localization;
+        await SettingsStore.init();
+        await Localization.init();
 
         for (const [option, entry] of Object.entries(ContextMenu.queryLinks)) {
             let [locale, query_, enabled] = entry;
@@ -109,7 +109,7 @@ export default class ContextMenu {
     }
 
     public static async update(): Promise<void> {
-        await SettingsStore;
+        await SettingsStore.init();
         if (!await Permissions.contains(["contextMenus"])) {
             Settings.context_steam_store = false;
             Settings.context_steam_market = false

--- a/src/js/Background/background.ts
+++ b/src/js/Background/background.ts
@@ -38,7 +38,7 @@ browser.runtime.onMessage.addListener((
 
     (async function(): Promise<void> {
         try {
-            await Promise.all([IndexedDB, SettingsStore]);
+            await Promise.all([IndexedDB.init(), SettingsStore.init()]);
 
             let response: any = undefined;
             let handlers: MessageHandlerInterface[] = [

--- a/src/js/Content/Features/Community/TradeOffer/PTradeOffer.ts
+++ b/src/js/Content/Features/Community/TradeOffer/PTradeOffer.ts
@@ -11,8 +11,8 @@ import {SettingsStore} from "@Options/Data/Settings";
 (async function() {
 
     try {
-        await SettingsStore;
-        await Localization;
+        await SettingsStore.init();
+        await Localization.init();
     } catch (err) {
         console.group("Augmented Steam initialization");
         console.error("Failed to initialize Augmented Steam");

--- a/src/js/Content/Features/Page.ts
+++ b/src/js/Content/Features/Page.ts
@@ -46,13 +46,13 @@ export default class Page {
         try {
             // TODO What errors can be "suppressed" here?
             try {
-                await SettingsStore;
+                await SettingsStore.init();
                 await bootstrapDomPurify();
             } catch (err) {
                 console.error(err);
             }
 
-            await Promise.all([Localization, User, CurrencyManager]);
+            await Promise.all([Localization.init(), User.init(), CurrencyManager.init()]);
         } catch (err) {
             console.group("Augmented Steam initialization");
             console.error("Failed to initialize Augmented Steam");

--- a/src/js/Content/Modules/Currency/CurrencyManager.ts
+++ b/src/js/Content/Modules/Currency/CurrencyManager.ts
@@ -93,7 +93,7 @@ export default class CurrencyManager {
         this._rates = await AugmentedSteamApiFacade.getRates(toCurrencies);
     }
 
-    private static init(): Promise<void> {
+    static init(): Promise<void> {
         if (!this.promise) {
             this.promise = (async () => {
                 try {
@@ -107,9 +107,5 @@ export default class CurrencyManager {
         }
 
         return this.promise;
-    }
-
-    private static then(onDone: (value: void) => void|Promise<void>): Promise<void> {
-        return CurrencyManager.init().then(onDone);
     }
 }

--- a/src/js/Content/Modules/Currency/CurrencyManager.ts
+++ b/src/js/Content/Modules/Currency/CurrencyManager.ts
@@ -7,7 +7,7 @@ import SteamStoreApiFacade from "@Content/Modules/Facades/SteamStoreApiFacade";
 
 export default class CurrencyManager {
 
-    private static _loadPromise: Promise<void>;
+    private static promise: Promise<void>;
     private static _rates: Record<string, Record<string, number>>;
 
     private static readonly _defaultCurrency: string = "USD";
@@ -93,9 +93,9 @@ export default class CurrencyManager {
         this._rates = await AugmentedSteamApiFacade.getRates(toCurrencies);
     }
 
-    static async init(): Promise<void> {
-        if (!this._loadPromise) {
-            this._loadPromise = (async () => {
+    private static init(): Promise<void> {
+        if (!this.promise) {
+            this.promise = (async () => {
                 try {
                     await this._loadCurrency();
                     await this._loadRates();
@@ -105,13 +105,11 @@ export default class CurrencyManager {
                 }
             })();
         }
-        return this._loadPromise;
+
+        return this.promise;
     }
 
-    static then(
-        onFulfil: (value: void) => PromiseLike<void>,
-        onReject: (value: void) => PromiseLike<never>
-    ) {
-        return CurrencyManager.init().then(onFulfil, onReject);
+    private static then(onDone: (value: void) => void|Promise<void>): Promise<void> {
+        return CurrencyManager.init().then(onDone);
     }
 }

--- a/src/js/Content/Modules/User.ts
+++ b/src/js/Content/Modules/User.ts
@@ -6,7 +6,7 @@ import RequestData from "@Content/Modules/RequestData";
 
 export default class User {
 
-    private static _promise: Promise<void>;
+    private static promise: Promise<void>;
 
     private static _signedIn: boolean;
     private static _steamId: string;
@@ -18,9 +18,9 @@ export default class User {
     private static _sessionId: string|null;
     private static _webApiToken: string;
 
-    static async promise(): Promise<void> {
-        if (!this._promise) {
-            this._promise = (async () => {
+    private static init(): Promise<void> {
+        if (!this.promise) {
+            this.promise = (async () => {
                 const avatarNode = document.querySelector<HTMLAnchorElement>("#global_actions > a.user_avatar");
 
                 try {
@@ -75,14 +75,11 @@ export default class User {
             })();
         }
 
-        return this._promise;
+        return this.promise;
     }
 
-    static then(
-        onFulfill: ((value: void) => PromiseLike<void>|void),
-        onReject: (reason: any) => PromiseLike<never>
-    ): Promise<void> {
-        return User.promise().then(onFulfill, onReject);
+    private static then(onDone: (value: void) => void|Promise<void>): Promise<void> {
+        return User.init().then(onDone);
     }
 
     static get isSignedIn(): boolean {

--- a/src/js/Content/Modules/User.ts
+++ b/src/js/Content/Modules/User.ts
@@ -18,7 +18,7 @@ export default class User {
     private static _sessionId: string|null;
     private static _webApiToken: string;
 
-    private static init(): Promise<void> {
+    static init(): Promise<void> {
         if (!this.promise) {
             this.promise = (async () => {
                 const avatarNode = document.querySelector<HTMLAnchorElement>("#global_actions > a.user_avatar");
@@ -76,10 +76,6 @@ export default class User {
         }
 
         return this.promise;
-    }
-
-    private static then(onDone: (value: void) => void|Promise<void>): Promise<void> {
-        return User.init().then(onDone);
     }
 
     static get isSignedIn(): boolean {

--- a/src/js/Core/Localization/Localization.ts
+++ b/src/js/Core/Localization/Localization.ts
@@ -13,16 +13,16 @@ interface TLocale {
 
 export default class Localization {
 
-    private static _promise: Promise<void>|null = null;
+    private static promise: Promise<void>;
     public static locale: TLocale;
 
     static load(code: string): Promise<TLocale> {
         return ExtensionResources.getJSON(`/localization/compiled/${code}.json`);
     }
 
-    static init(): Promise<void> {
-        if (!this._promise) {
-            this._promise = (async () => {
+    private static init(): Promise<void> {
+        if (!this.promise) {
+            this.promise = (async () => {
                 const stored = Settings.language;
                 let current = Language.getCurrentSteamLanguage();
                 if (current === null) {
@@ -43,14 +43,11 @@ export default class Localization {
             })();
         }
 
-        return this._promise;
+        return this.promise;
     }
 
-    static then(
-        onfulfilled: ((value: void) => Promise<void>) | undefined | null,
-        onrejected: ((reason: any) => Promise<void>) | undefined | null
-    ): Promise<void> {
-        return Localization.init().then(onfulfilled, onrejected);
+    private static then(onDone: (value: void) => void|Promise<void>): Promise<void> {
+        return Localization.init().then(onDone);
     }
 }
 

--- a/src/js/Core/Localization/Localization.ts
+++ b/src/js/Core/Localization/Localization.ts
@@ -20,7 +20,7 @@ export default class Localization {
         return ExtensionResources.getJSON(`/localization/compiled/${code}.json`);
     }
 
-    private static init(): Promise<void> {
+    static init(): Promise<void> {
         if (!this.promise) {
             this.promise = (async () => {
                 const stored = Settings.language;
@@ -44,10 +44,6 @@ export default class Localization {
         }
 
         return this.promise;
-    }
-
-    private static then(onDone: (value: void) => void|Promise<void>): Promise<void> {
-        return Localization.init().then(onDone);
     }
 }
 

--- a/src/js/Options/Data/Settings.ts
+++ b/src/js/Options/Data/Settings.ts
@@ -222,15 +222,11 @@ export class SettingsStore {
         this.data = await this.storage.getObject(DefaultSettings);
     }
 
-    private static init(): Promise<void> {
+    static init(): Promise<void> {
         if (!this.promise) {
             this.promise = this.load();
         }
         return this.promise;
-    }
-
-    private static then(onDone: (value: void) => void|Promise<void>): Promise<void> {
-        return this.init().then(onDone);
     }
 
     static getDefault<K extends keyof SettingsSchema>(key: K): SettingsSchema[K] {

--- a/src/js/Options/Data/Settings.ts
+++ b/src/js/Options/Data/Settings.ts
@@ -210,7 +210,7 @@ class Event {
 
 export class SettingsStore {
 
-    private static initPromise: Promise<void>;
+    private static promise: Promise<void>;
 
     private static data: SettingsSchema;
     private static storage: StorageInterface<SettingsSchema> = new SyncedStorage<SettingsSchema>();
@@ -222,19 +222,15 @@ export class SettingsStore {
         this.data = await this.storage.getObject(DefaultSettings);
     }
 
-    static async init(): Promise<void> {
-        if (!this.initPromise) {
-            this.initPromise = this.load();
+    private static init(): Promise<void> {
+        if (!this.promise) {
+            this.promise = this.load();
         }
-        return this.initPromise;
+        return this.promise;
     }
 
-    // init shortcut
-    static then(
-        onDone: (value: void) => PromiseLike<void>,
-        onCatch: (reason: any) => PromiseLike<never>
-    ): Promise<void> {
-        return this.init().then(onDone, onCatch);
+    private static then(onDone: (value: void) => void|Promise<void>): Promise<void> {
+        return this.init().then(onDone);
     }
 
     static getDefault<K extends keyof SettingsSchema>(key: K): SettingsSchema[K] {

--- a/src/js/Options/OptionsPage.svelte
+++ b/src/js/Options/OptionsPage.svelte
@@ -20,8 +20,8 @@
 
     onMount(() => {
         initialLoad = (async () => {
-            await SettingsStore
-            await Localization;
+            await SettingsStore.init();
+            await Localization.init();
         })();
     });
 

--- a/src/js/bootstrapDomPurify.ts
+++ b/src/js/bootstrapDomPurify.ts
@@ -12,7 +12,7 @@ export default async function() {
     if (initialized) { return; }
     initialized = true;
 
-    await SettingsStore;
+    await SettingsStore.init();
     const allowOpenInNewTab = Settings.openinnewtab;
 
     /*


### PR DESCRIPTION
I think these `.then` argument types are to make TS happy? Otherwise you run into `Type of 'await' operand must either be a valid promise or must not contain a callable 'then' member` when doing `await SomeClass` 🤔

In any case, we shouldn't be calling these `.then` or `.init` methods externally, so mark them as private and simplify `.then` arguments.