### PR TITLE
Fix profile wishlist count for non-English locales

### DIFF
--- a/src/js/Content/Features/Store/App/FPlayers.svelte
+++ b/src/js/Content/Features/Store/App/FPlayers.svelte
@@ -6,7 +6,7 @@
     export let peakToday: number;
     export let peakAll: number;
 
-    let formatter = new Intl.NumberFormat(navigator.language);
+    const formatter = new Intl.NumberFormat(document.documentElement.lang || navigator.language);
 </script>
 
 


### PR DESCRIPTION
Also attempt to format the value using Steam locale first, otherwise fallback to browser locale. Maybe we should extract the formatter into a util class?