### PR TITLE
Fix checkbox position on recommended DLC row

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1264,18 +1264,26 @@ video.highlight_movie:hover + .html5_video_overlay {
   display: none; /* hide dlc flag due to checkboxes (if highlighting is disabled) */
 }
 
-#es_dlc_option_panel + .game_area_dlc_list .game_area_dlc_name {
-  margin-left: 23px; /* move title out of the way */
+#es_dlc_option_panel + .game_area_dlc_list .game_area_dlc_row:not(.dlc_highlight) .game_area_dlc_name {
+  margin-left: 21px; /* if there're checkboxes, align the titles for non-recommended free dlcs */
+}
+
+.game_area_dlc_row:not(.dlc_highlight) .game_area_dlc_name:has(.es_dlc_label) {
+  display: flex;
+  margin-left: -4px !important;
+  padding: 0;
+}
+.game_area_dlc_row.dlc_highlight > div:first-child:has(.es_dlc_label) {
+  display: flex;
+  margin-left: -12px !important;
 }
 
 label.es_dlc_label {
-  position: absolute;
-  padding: 4px 11px 1px;
-  z-index: 999;
+  display: flex;
+  align-items: center;
+  padding: 0px 10px;
 }
 label.es_dlc_label > input {
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   background-color: #545454;
   padding: 6px;
@@ -1289,7 +1297,10 @@ label.es_dlc_label > input:checked::after {
   font-size: 12px;
   position: absolute;
   bottom: 4px;
-  left: 13px;
+  left: 12px;
+}
+.dlc_highlight label.es_dlc_label > input:checked::after {
+  bottom: 31px;
 }
 
 /***************************************

--- a/src/js/Content/Features/Store/App/FDLCCheckboxes.ts
+++ b/src/js/Content/Features/Store/App/FDLCCheckboxes.ts
@@ -55,7 +55,23 @@ export default class FDLCCheckboxes extends Feature<CApp> {
             }
 
             label.append(checkbox);
-            dlcRow.before(label);
+
+            const node = dlcRow.querySelector<HTMLElement>(":scope > div:first-child");
+            if (!node) { continue; }
+
+            // TODO remove when min version is increased to FF 121
+            if (!CSS.supports("selector(:has(a))")) {
+                if (dlcRow.classList.contains("dlc_highlight")) {
+                    node.style.display = "flex";
+                    node.style.marginLeft = "-12px";
+                } else {
+                    node.style.display = "flex";
+                    node.style.marginLeft = "-4px";
+                    node.style.padding = "0";
+                }
+            }
+
+            node.prepend(label);
         }
 
         // Toggle dsinfo on label when adding/removing wishlist via ds_options dropdown
@@ -65,8 +81,8 @@ export default class FDLCCheckboxes extends Feature<CApp> {
                 if (!target.classList.contains("game_area_dlc_row")) { continue; }
 
                 // Prevent errors when there're no labels, e.g. free dlcs
-                const label = target.previousElementSibling;
-                if (!label?.classList.contains("es_dlc_label")) { continue; }
+                const label = target.querySelector(".es_dlc_label");
+                if (!label) { continue; }
 
                 label.classList.toggle("es_dlc_wishlist", target.classList.contains("ds_wishlist"));
             }


### PR DESCRIPTION
For testing: `https://store.steampowered.com/app/493340/`

Had to revert to the old way of inserting the checkbox within the row, fortunately there's the `:has()` selector now, though I added a fallback until we increase the min version.