### PR TITLE
NotesForm: Dispatch change event on input when hitting Enter

### DIFF
--- a/src/js/Content/Features/Store/Common/UserNotes/NotesForm.svelte
+++ b/src/js/Content/Features/Store/Common/UserNotes/NotesForm.svelte
@@ -17,6 +17,7 @@
          */
         input.addEventListener("keydown", e => {
             if (e.key === "Enter" && !e.shiftKey) {
+                input.dispatchEvent(new Event("change")); // Workaround for FF
                 document.querySelector<HTMLElement>(".newmodal_buttons > .btn_medium")?.click();
             }
         });


### PR DESCRIPTION
I didn't look into the details, but it seems like FF doesn't fire the change event when the input loses focus due to a programmatically fired click event. This is just a quick workaround for the issue.

Fixes #2057