### PR TITLE
BlockingWaitDialog: Ensure it's the wait dialog that's dismissed

### DIFF
--- a/src/js/Content/Features/Community/WorkshopBrowse/FWorkshopSubscriberButtons.ts
+++ b/src/js/Content/Features/Community/WorkshopBrowse/FWorkshopSubscriberButtons.ts
@@ -75,7 +75,6 @@ export default class FWorkshopSubscriberButtons extends Feature<CWorkshopBrowse>
             return;
         }
 
-        SteamFacade.dismissActiveModal();
         const waitDialog = new BlockingWaitDialog(
             this._statusTitle,
             () => this.getStatus()

--- a/src/js/Content/Modules/Facades/SteamFacade.ts
+++ b/src/js/Content/Modules/Facades/SteamFacade.ts
@@ -57,8 +57,8 @@ export default class SteamFacade {
         ]);
     }
 
-    static dismissActiveModal() {
-        Messenger.call(MessageHandler.SteamFacade, "dismissActiveModal");
+    static dismissActiveModal(id?: string): void {
+        Messenger.call(MessageHandler.SteamFacade, "dismissActiveModal", [id]);
     }
 
     // menu

--- a/src/js/Core/Modals/BlockingWaitDialog.ts
+++ b/src/js/Core/Modals/BlockingWaitDialog.ts
@@ -30,10 +30,10 @@ export default class BlockingWaitDialog {
         }
     }
 
-     dismiss(): void {
+    dismiss(): void {
         const container = this.getContainer();
         if (container) {
-            SteamFacade.dismissActiveModal();
+            SteamFacade.dismissActiveModal(this.id);
         }
     }
 }

--- a/src/scriptlets/SteamScriptlet.js
+++ b/src/scriptlets/SteamScriptlet.js
@@ -51,8 +51,17 @@
             });
         }
 
-        static dismissActiveModal() {
-            CModal.DismissActiveModal();
+        static dismissActiveModal(id) {
+            if (id) {
+                for (const modal of CModal.s_rgModalStack) {
+                    if (modal.GetContent().find(`#${id}`).length > 0) {
+                        modal.Dismiss();
+                        break;
+                    }
+                }
+            } else {
+                CModal.DismissActiveModal();
+            }
         }
 
         // menu


### PR DESCRIPTION
This is another issue with dynamic scripts like #1944. `dismissActiveModal()` might run much later, and dismiss the follow-up dialog instead of the wait dialog. This adds an id param to `dismissActiveModal()` to ensure it's the wait dialog that's dismissed.