### PR TITLE
Avoid escaping reserved characters when formatting URL

### DIFF
--- a/src/js/Core/Html/Html.ts
+++ b/src/js/Core/Html/Html.ts
@@ -5,7 +5,7 @@ export default class HTML {
     static formatUrl(link: string): string {
         const protocolReg = /^[a-z]+:\/\//;
         const _link = protocolReg.test(link) ? link : `//${link}`;
-        return this.escape(_link);
+        return encodeURI(_link);
     }
 
     static escape(str: string): string {


### PR DESCRIPTION
All uses of `HTML.formatUrl` formats a whole URL, so we should leave special characters as-is.

Fixes #2061.