### PR TITLE
Fix for `browser.storage.sync.QUOTA_BYTES_PER_ITEM` being undefined on FF

### DIFF
--- a/src/js/Core/Storage/SyncedStorage.ts
+++ b/src/js/Core/Storage/SyncedStorage.ts
@@ -32,7 +32,8 @@ export class SyncedStorage<Schema extends StorageSchema> extends Storage<ns.Sync
     }
 
     get QUOTA_BYTES_PER_ITEM(): number {
-        return browser.storage.sync.QUOTA_BYTES_PER_ITEM;
+        // see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/66696
+        return browser.storage.sync.QUOTA_BYTES_PER_ITEM ?? 8192;
     }
 }
 


### PR DESCRIPTION
I tried updating @types/webextension-polyfill to reflect this, but there're a couple of breaking changes that make it not so straight forward (mainly type changes from `any` to `unknown`), so I just restored the old logic for now.

Fixes the out of capacity dialog not showing on FF, related to #2065.