### PR TITLE
Add support for fastly CDN, make CDN optional

### DIFF
--- a/src/js/Content/Modules/Widgets/AugmentedSteamMenu.svelte
+++ b/src/js/Content/Modules/Widgets/AugmentedSteamMenu.svelte
@@ -48,7 +48,7 @@
 
         const confirm = await SteamFacade.showConfirmDialog(
             L(__playGame, {gamename}),
-            `<img src="//cdn.cloudflare.steamstatic.com/steam/apps/${gameid}/header.jpg">`,
+            `<img src="//shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/${gameid}/header.jpg">`,
             {
                 secondaryActionButton: L(__visitStore)
             }

--- a/src/js/Core/GameId/AppId.ts
+++ b/src/js/Core/GameId/AppId.ts
@@ -9,8 +9,8 @@ export default class AppId {
     }
 
     static fromCDNUrl(url: string): number|null {
-        const CDNRegex_1 = /(?:cdn\.(?:akamai|cloudflare)\.steamstatic\.com\/steam|steamcdn-a\.akamaihd\.net\/steam|steamcommunity\/public\/images)\/apps\/(\d+)\//;
-        const CDNRegex_2 = /shared\.(?:akamai|cloudflare)\.steamstatic\.com\/store_item_assets\/steam\/apps\/(\d+)\//;
+        const CDNRegex_1 = /(?:cdn\.(?:(?:akamai|cloudflare|fastly)\.)?steamstatic\.com\/steam|steamcdn-a\.akamaihd\.net\/steam|steamcommunity\/public\/images)\/apps\/(\d+)\//;
+        const CDNRegex_2 = /shared\.(?:(?:akamai|cloudflare|fastly)\.)?steamstatic\.com\/store_item_assets\/steam\/apps\/(\d+)\//;
         const m = url.match(CDNRegex_1) ?? url.match(CDNRegex_2);
         return m && m[1] !== undefined
             ? Number(m[1])

--- a/src/scriptlets/Store/Wishlist/hiddenApps.js
+++ b/src/scriptlets/Store/Wishlist/hiddenApps.js
@@ -16,7 +16,7 @@
     const html = (window.asHiddenApps ??= hiddenApps).map(appid => {
         return `<div class="as-wl-remove-row" data-appid="${appid}">
                 <a href="//steamcommunity.com/app/${appid}/discussions/" target="_blank">
-                    <img src="//cdn.cloudflare.steamstatic.com/steam/apps/${appid}/header_292x136.jpg" loading="lazy">
+                    <img src="//shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/${appid}/header_292x136.jpg" loading="lazy">
                 </a>
                 <a href="https://isthereanydeal.com/steam/app/${appid}/" target="_blank"><img src="${icons.itad}" title="ITAD"></a>
                 <a href="https://steamdb.info/app/${appid}/" target="_blank"><img src="${icons.steamdb}" title="SteamDB"></a>


### PR DESCRIPTION
Seems like most store assets are now linked from `shared.steamstatic.com`, and only community stuff are left on `cdn.steamstatic.com`