### PR TITLE
Refactor wishlist profile link count

### DIFF
--- a/src/js/Background/EAction.ts
+++ b/src/js/Background/EAction.ts
@@ -35,7 +35,6 @@ export enum EAction {
 
     Wishlist_Add = "wishlist.add",
     Wishlist_Remove = "wishlist.remove",
-    Wishlists = "wishlists",
     AppDetails = "appdetails",
     Currency = "currency",
     SessionId = "sessionid",

--- a/src/js/Background/Modules/Store/SteamStoreApi.ts
+++ b/src/js/Background/Modules/Store/SteamStoreApi.ts
@@ -4,7 +4,6 @@ import IndexedDB from "@Background/Db/IndexedDB";
 import type {
     TAppDetail,
     TDynamicStoreStatusResponse,
-    TFetchWishlistResponse,
     TPackageDetail,
     TWishlistGame
 } from "./_types";
@@ -178,13 +177,6 @@ export default class SteamStoreApi extends Api implements MessageHandlerInterfac
         return HTMLParser.getStringVariable("g_sessionID", html);
     }
 
-    private async fetchWishlistCount(path: string): Promise<TFetchWishlistResponse> {
-        const url = this.getUrl(`/wishlist${path}`);
-        const html = await this.fetchPage(url);
-        const data = HTMLParser.getArrayVariable<TWishlistGame>("g_rgWishlistData", html);
-        return data?.length ?? null;
-    }
-
     private async fetchPurchaseDates(lang: string): Promise<Array<[string, string]>> {
         const url = this.getUrl("/account/licenses/", {"l": lang});
         const html = await this.fetchPage(url);
@@ -336,9 +328,6 @@ export default class SteamStoreApi extends Api implements MessageHandlerInterfac
 
             case EAction.Wishlist_Remove:
                 return this.wishlistRemove(message.params.appid);
-
-            case EAction.Wishlists:
-                return this.fetchWishlistCount(message.params.path);
 
             case EAction.AppDetails:
                 return this.fetchAppDetails(message.params.appid, message.params.filter ?? undefined);

--- a/src/js/Background/Modules/Store/_types.ts
+++ b/src/js/Background/Modules/Store/_types.ts
@@ -58,8 +58,6 @@ export interface TWishlistGame {
     }
 }
 
-export type TFetchWishlistResponse = number|null
-
 export interface TDynamicStoreStatusResponse {
     ignored: string[],
     ignoredOwned: string[],

--- a/src/js/Content/Features/Community/ProfileHome/FWishlistProfileLink.svelte
+++ b/src/js/Content/Features/Community/ProfileHome/FWishlistProfileLink.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
     import {onMount} from "svelte";
     import {__wishlist} from "@Strings/_strings";
-    import SteamStoreApiFacade from "@Content/Modules/Facades/SteamStoreApiFacade";
-    import Settings from "@Options/Data/Settings";
     import {L} from "@Core/Localization/Localization";
+    import Settings from "@Options/Data/Settings";
+    import RequestData from "@Content/Modules/RequestData";
+
+    export let steamid: string;
 
     let countPromise: Promise<string|null> = Promise.resolve(null);
 
@@ -16,11 +18,17 @@
                     return valueNode.textContent!.trim();
                 }
 
-                const count = await SteamStoreApiFacade.fetchWishlistCount(window.location.pathname);
-                if (count !== null) {
+                const data = await RequestData.getJson<{
+                    response: {
+                        count: number
+                    }
+                }>(`https://api.steampowered.com/IWishlistService/GetWishlistItemCount/v1/?steamid=${steamid}`, {credentials: "omit"});
+                if (data.response.count) {
+                    // Don't show if count is 0
                     const formatter = new Intl.NumberFormat(document.documentElement.lang || navigator.language);
-                    return formatter.format(count);
+                    return formatter.format(data.response.count);
                 }
+
                 return null;
             })();
         }

--- a/src/js/Content/Features/Community/ProfileHome/FWishlistProfileLink.ts
+++ b/src/js/Content/Features/Community/ProfileHome/FWishlistProfileLink.ts
@@ -6,7 +6,9 @@ import Settings from "@Options/Data/Settings";
 export default class FWishlistProfileLink extends Feature<CProfileHome> {
 
     override checkPrerequisites(): boolean {
-        return !this.context.isPrivateProfile && Settings.show_wishlist_link;
+        return !this.context.isPrivateProfile
+            && this.context.steamId !== null
+            && Settings.show_wishlist_link;
     }
 
     override async apply(): Promise<void> {
@@ -14,7 +16,10 @@ export default class FWishlistProfileLink extends Feature<CProfileHome> {
         const node = document.querySelector(".profile_item_links .profile_count_link")!;
         new self_({
             target: node.parentElement!,
-            anchor: node.nextElementSibling!
+            anchor: node.nextElementSibling!,
+            props: {
+                steamid: this.context.steamId!
+            }
         });
     }
 }

--- a/src/js/Content/Modules/Facades/SteamStoreApiFacade.ts
+++ b/src/js/Content/Modules/Facades/SteamStoreApiFacade.ts
@@ -1,6 +1,6 @@
 import Background from "@Core/Background";
 import {EAction} from "@Background/EAction";
-import type {TAppDetail, TDynamicStoreStatusResponse, TFetchWishlistResponse} from "@Background/Modules/Store/_types";
+import type {TAppDetail, TDynamicStoreStatusResponse} from "@Background/Modules/Store/_types";
 
 export default class SteamStoreApiFacade {
 
@@ -10,10 +10,6 @@ export default class SteamStoreApiFacade {
 
     static wishlistRemove(appid: number): Promise<void> {
         return Background.send(EAction.Wishlist_Remove, {appid});
-    }
-
-    static fetchWishlistCount(path: string): Promise<TFetchWishlistResponse> {
-        return Background.send(EAction.Wishlists, {path});
     }
 
     static fetchAppDetails(appid: number, filter: string|undefined=undefined): Promise<TAppDetail|null> {


### PR DESCRIPTION
`/IWishlistService/GetWishlistItemCount/` now returns the specified steamid's count, and no longer requires an access token.