### PR TITLE
Fix accidental dismissal of MultipleProductKey dialog

### DIFF
--- a/src/js/Content/Features/Store/RegisterKey/FMultiProductKeys.ts
+++ b/src/js/Content/Features/Store/RegisterKey/FMultiProductKeys.ts
@@ -185,6 +185,8 @@ export default class FMultiProductKeys extends Feature<CRegisterKey> {
                 "__alreadyentered__",
                 document.querySelector<HTMLInputElement>("#product_key")!.value.replace(/,/g, "\n")
             ),
+          // avoid losing user inputted keys by making dialog dismissal an explicit interaction
+          { bExplicitDismissalOnly: true }
         );
     }
 }


### PR DESCRIPTION
## Overview 📄

Hey folks, this PR aims to improve the experience of user input when filling out Multiple Product Keys, by turning off dialog dismissals that could happen accidentally.

This came out of my own "Oh no, all my keys!" moment, when I accidentally clicked outside of the dialog.

## Problem 🤔

| | |
|--------|--------|
| ![](https://github.com/user-attachments/assets/3eaa6621-39a1-46e0-af9b-11557d429119) | ![](https://github.com/user-attachments/assets/d63566ca-d1c6-474b-9ba2-4c4eee559cf8) |
| The "Multiple Product Keys" dialog | The clickable "outside" element | 

The following are user interactions to dismiss the Multple Product Keys dialog, and the changes made to each  

**🖱️ Mouse**
1. Clicking the "Close" button inside of the dialog.  
  👍 No changes.
2. Clicking outside of the dialog (_e.g. in the red shown above_).  
  💥 **This has now been disabled.**

**⌨️ Keyboard**
1. Pressing Escape on the keyboard.
  💥 **This has now been disabled.**

The latter two user interactions can be awkward and were at fault for me personally, so I'm got rid of 'em.

Ideally, an alert of some kind like "You have unsaved Product Keys" canceable alert shown before dialog dismissal would be the solution I'd aim for, but I'm unfamiliar with the codebase and the solution in this PR seemed a reasonable shortcut.

## Solution 🚀

There is a `bExplicitDismissalOnly` param that can be passed to the underlying `CModal` implementation in the SteamScriplet, this takes advantage of that! It's already in use in this extension, so I reckon it's a safe usage.