### PR TITLE
Updated badge binder view height

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -224,7 +224,7 @@ img.astats_icon {
   height: 24px !important;
 }
 .es_binder_view .badge_row_inner {
-  height: 195px !important;
+  height: 210px !important;
 }
 .es_binder_view .badge_current {
   width: 100% !important;
@@ -243,7 +243,7 @@ img.astats_icon {
 }
 .es_binder_view .badge_row {
   width: 160px !important;
-  height: 195px !important;
+  height: 210px !important;
   float: left;
   margin-right: 15px !important;
   margin-bottom: 15px !important;


### PR DESCRIPTION
Added more height to badge binder view because the text was getting outside on some badges. Tried to rewrite with flex or grid, it's really messy, reverted to fixed height.

![image](https://github.com/user-attachments/assets/e879e76f-40b4-47dc-8449-a3f015b556a9)
![image](https://github.com/user-attachments/assets/d1cab5ba-ceed-4d72-90aa-4130cc384869)
