### PR TITLE
Add 'unlimitedStorage' permission to resolve QUOTA_BYTES_PER_ITEM

### DIFF
--- a/scripts/tools/manifest.mjs
+++ b/scripts/tools/manifest.mjs
@@ -15,6 +15,7 @@ export default {
     },
     permissions: [
         "storage",
+        "unlimitedStorage",
         "contextMenus",
         "webRequest"
     ],


### PR DESCRIPTION
When adding a note I was encountering an 'Uncaught (in promise) Error: QUOTA_BYTES_PER_ITEM quota exceeded' due to storage limitations. 

This commit addresses the issue by granting 'unlimitedStorage' permission, which allows 
the application to handle larger data volumes without hitting the quota limit.