### PR TITLE
fix: filter out empty tiers in bundle overview (#2120)

### DIFF
--- a/src/js/Content/Modules/Prices/BundleOverview.svelte
+++ b/src/js/Content/Modules/Prices/BundleOverview.svelte
@@ -14,6 +14,15 @@
 
     export let data: TBundle[];
 
+    /**
+     * Filters out tiers that contain no games to prevent displaying empty tier sections
+     * @param bundle The bundle containing tiers to filter
+     * @returns Array of tiers that have at least one game
+     */
+    function getNonEmptyTiers(bundle: TBundle) {
+        return bundle.tiers.filter(tier => tier.games.length > 0);
+    }
+
     function getPrice(price: TPrice): Price {
         let tierPrice = new Price(price.amount, price.currency);
         try {
@@ -57,7 +66,7 @@
                 {/if}
 
                 <p class="package_contents">
-                    {#each bundle.tiers as tier, num}
+                    {#each getNonEmptyTiers(bundle) as tier, num}
                         <b class="as_bundle_tier_title"> <!-- class added for compatibility with Steam Currency Converter -->
                             {#if bundle.tiers.length > 1}
                                 {L(__bundle_tierIncludes, {


### PR DESCRIPTION
- Add getNonEmptyTiers function to remove tiers without games
- Prevent display of "Tier X includes 0 items" sections
- Add JSDoc documentation for maintainability

The change improves UI clarity by filtering out bundle tiers that  contain no games, while maintaining all functionality for populated tiers.

Fixes #2120 