### PR TITLE
Add Give Steam Community Award to profile dropdown options

### DIFF
--- a/src/js/Content/Features/Community/ProfileHome/FProfileAwardButton.svelte
+++ b/src/js/Content/Features/Community/ProfileHome/FProfileAwardButton.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { __giveAward } from "@Strings/_strings";
+	import { L } from "@Core/Localization/Localization";
+</script>
+
+<a class="popup_menu_item es_award_button" id="es_award" role="button">
+	<img
+		src="//community.fastly.steamstatic.com/public/shared/images/award_icon.svg"
+		alt="Steam Community Award Icon"
+	/>&nbsp; {L(__giveAward)}
+</a>
+
+<style>
+	.es_award_button img {
+		top: 5px !important;
+	}
+</style>

--- a/src/js/Content/Features/Community/ProfileHome/FProfileDropdownOptions.ts
+++ b/src/js/Content/Features/Community/ProfileHome/FProfileDropdownOptions.ts
@@ -1,39 +1,73 @@
-import {__addNickname, __postHistory} from "@Strings/_strings";
-import {L} from "@Core/Localization/Localization";
-import type CProfileHome from "@Content/Features/Community/ProfileHome/CProfileHome";
-import Feature from "@Content/Modules/Context/Feature";
-import HTML from "@Core/Html/Html";
-import DOMHelper from "@Content/Modules/DOMHelper";
+import { __addNickname, __postHistory } from '@Strings/_strings';
+import { L } from '@Core/Localization/Localization';
+import FProfileAwardButton from './FProfileAwardButton.svelte';
+import type CProfileHome from '@Content/Features/Community/ProfileHome/CProfileHome';
+import Feature from '@Content/Modules/Context/Feature';
+import HTML from '@Core/Html/Html';
+import DOMHelper from '@Content/Modules/DOMHelper';
 
 export default class FProfileDropdownOptions extends Feature<CProfileHome> {
+	private _node: HTMLElement | null = null;
+	private _path: string = '';
 
-    private _node: HTMLElement|null = null;
+	override checkPrerequisites(): boolean {
+		this._node = document.querySelector(
+			'#profile_action_dropdown .popup_body .profile_actions_follow',
+		);
+		return this._node !== null;
+	}
 
-    override checkPrerequisites(): boolean {
-        this._node = document.querySelector("#profile_action_dropdown .popup_body .profile_actions_follow");
-        return this._node !== null;
-    }
+	override apply(): void {
+		this._path = window.location.pathname.match(
+			/\/((?:id|profiles)\/[^\/]+)/,
+		)![1]!;
 
-    override apply(): void {
-
-        // add nickname option for non-friends
-        if (this.context.user.isSignedIn) {
-
-            // Selects the "Add Friend" button (ID selector for unblocked, class selector for blocked users)
-            if (document.querySelector("#btn_add_friend, .profile_header_actions > .btn_profile_action_disabled")) {
-                HTML.afterEnd(this._node,
-                    `<a class="popup_menu_item" id="es_nickname">
+		// add nickname option for non-friends
+		if (this.context.user.isSignedIn) {
+			// Selects the "Add Friend" button (ID selector for unblocked, class selector for blocked users)
+			if (
+				document.querySelector(
+					'#btn_add_friend, .profile_header_actions > .btn_profile_action_disabled',
+				)
+			) {
+				HTML.afterEnd(
+					this._node,
+					`<a class="popup_menu_item" id="es_nickname">
                         <img src="//community.cloudflare.steamstatic.com/public/images/skin_1/notification_icon_edit_bright.png">&nbsp; ${L(__addNickname)}
-                    </a>`);
-            }
+                    </a>`,
+				);
+			}
 
-            DOMHelper.insertScript("scriptlets/Community/ProfileHome/profileDropdown.js");
-        }
+			DOMHelper.insertScript(
+				'scriptlets/Community/ProfileHome/profileDropdown.js',
+			);
+		}
 
-        // add post history link
-        HTML.afterEnd(this._node,
-            `<a class="popup_menu_item" href="${window.location.pathname}/posthistory">
+		// add give awards option for hidden profiles
+		if (this.context.user.isSignedIn) {
+			const loginURL = encodeURIComponent(
+				`https://steamcommunity.com/login/home/?goto=${this._path}/?insideModal=0`,
+			);
+
+			// Selects the default "Give Award" button
+			if (!document.querySelector('.reward_btn_icon[data-tooltip-text]') && this._node) {
+				new FProfileAwardButton({
+					target: this._node,
+				});
+			}
+
+			DOMHelper.insertScript('scriptlets/Community/ProfileHome/awardDropdown.js', {
+				loginURL,
+				steamId: this.context.steamId,
+			});
+		}
+
+		// add post history link
+		HTML.afterEnd(
+			this._node,
+			`<a class="popup_menu_item" href="${window.location.pathname}/posthistory">
                 <img src="//community.cloudflare.steamstatic.com/public/images/skin_1/icon_btn_comment.png">&nbsp; ${L(__postHistory)}
-            </a>`);
-    }
+            </a>`,
+		);
+	}
 }

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -54,6 +54,7 @@
     "fav_emoticons_dragging": "Drag emoticons here to favorite them",
     "fav_emoticons_no_access": "You don't have access to this emoticon",
     "post_history": "View post history",
+    "give_award": "Give a Community Award",
     "add_nickname": "Add Nickname",
     "total_size": "Total Size",
     "dlc_details": "Downloadable Content Details",

--- a/src/scriptlets/Community/ProfileHome/awardDropdown.js
+++ b/src/scriptlets/Community/ProfileHome/awardDropdown.js
@@ -1,0 +1,9 @@
+(function () {
+    const params = JSON.parse(document.currentScript.dataset.params);
+    loginURL = params.loginURL;
+    steamId = params.steamId;
+
+	document.querySelector('#es_award')?.addEventListener('click', () => {
+		window.AddProfileAward(1, loginURL, steamId);
+	});
+})();


### PR DESCRIPTION
Added a new option to the dropdown menu to give community awards to profiles that don't have this button already

<details>
  <summary>Profile with a default button</summary>
    <img src="https://github.com/user-attachments/assets/62bad9e3-d20e-4b4c-847f-b1aaedf2e1c2" alt="Profile with a default button">
</details>

<details>
  <summary>Profile without one</summary>
    <img src="https://github.com/user-attachments/assets/89f98aa1-8a3d-421a-b77a-98b3a18291a1" alt="Profile without a default button">
</details>
