### PR TITLE
Fix cart history link placement

### DIFF
--- a/src/js/Content/Features/Store/Cart/FCartHistoryLink.ts
+++ b/src/js/Content/Features/Store/Cart/FCartHistoryLink.ts
@@ -15,7 +15,7 @@ export default class FCartHistoryLink extends Feature<CCart> {
             new MutationObserver((_, observer) => {
                 observer.disconnect();
                 resolve(
-                    root.querySelector<HTMLElement>(":scope > div:first-child > div:last-child > div:last-child")
+                    root.querySelector<HTMLElement>(":scope > div:first-child > div:first-child > div:last-child > div:last-child")
                 );
             }).observe(root, {"childList": true, "subtree": true});
         });


### PR DESCRIPTION
Fixes this issue - https://github.com/IsThereAnyDeal/AugmentedSteam/issues/2167

Explanation: an additional `div` was added to `[data-featuretarget="react-root"]` element on Steam page

<details>
	<summary>Old react-root</summary>
	<div>
		<img src="https://github.com/user-attachments/assets/f97d5718-e66f-49c6-b4be-66d058b0512d">
	</div>
</details>

<details>
	<summary>New react-root</summary>
	<div>
		<img src="https://github.com/user-attachments/assets/45b81033-3b1c-4ae8-8eae-da93227a05d0">
	</div>
</details>
