### PR TITLE
Fix hidden apps in wishlist stats pop-up

### DIFF
--- a/src/js/Content/Features/Store/Wishlist/Components/WishlistStats.svelte
+++ b/src/js/Content/Features/Store/Wishlist/Components/WishlistStats.svelte
@@ -13,7 +13,7 @@
     import {
         CStoreBrowse_GetItems_Request,
         CStoreBrowse_GetItems_Response,
-        type IStoreItemID, StoreBrowseContext, StoreBrowseItemDataRequest, StoreItemID
+        type IStoreItem, type IStoreItemID, StoreBrowseContext, StoreBrowseItemDataRequest, StoreItemID
     } from "@Protobufs/Compiled/proto.bundle";
     import ServiceFactory from "@Protobufs/ServiceFactory";
     import ProtobufUtils from "@Protobufs/ProtobufUtils";
@@ -37,7 +37,7 @@
     let totalPrice: number = 0;
     let onSaleCount: number = 0;
     let noPriceCount: number = 0;
-    let hiddenApps: IStoreItemID[] = [];
+    let hiddenApps: IStoreItem[] = [];
 
     let promise: Promise<void>;
 
@@ -106,11 +106,11 @@
         hiddenApps = hiddenApps;
     }
 
-    async function handleRemove(app: IStoreItemID): Promise<void> {
+    async function handleRemove(app: IStoreItem): Promise<void> {
         await ServiceFactory.WishlistService(user)
-            .removeFromWishlist({appid: app.appid!});
+            .removeFromWishlist({appid: app.id!});
 
-        const index = hiddenApps.findIndex(id => id.appid === app.appid!);
+        const index = hiddenApps.findIndex(item => item.id === app.id!);
         if (index >= 0) {
             hiddenApps.splice(index, 1);
             hiddenApps = hiddenApps;
@@ -180,8 +180,8 @@
     {#key hiddenApps}
         {#if isHiddenOpen && hiddenApps && hiddenApps.length > 0}
             <Modal title="Hidden apps" showClose on:button={() => isHiddenOpen = false}>
-                {#each hiddenApps as app (app.appid)}
-                    {@const appid = app.appid}
+                {#each hiddenApps as app (app.id)}
+                    {@const appid = app.id}
                     <div class="unlisted">
                         <a href="https://steamcommunity.com/app/{appid}/discussions/" target="_blank">
                             <img src="https://shared.fastly.steamstatic.com/store_item_assets/steam/apps/{appid}/header_292x136.jpg" class="banner" alt="Banner" loading="lazy" />


### PR DESCRIPTION
Seems like Valve recently made some changes here, and now the `appid` value in `page.storeItems` is `0` for hidden apps instead of their actual app ID. It looks like we can simply use the `id` value to get the actual app ID instead.

As a result of these changes, the `Hidden apps` window now looks like this:
<img width="514" height="653" alt="obraz" src="https://github.com/user-attachments/assets/49cc225d-9194-47f0-b817-995f1100a497" />

For example, here's what an entry for a hidden app looks like:
```
{
    "includedTypes": [],
    "includedAppids": [],
    "contentDescriptorids": [],
    "tagids": [],
    "tags": [],
    "purchaseOptions": [],
    "accessories": [],
    "invalidPurchaseOptions": [],
    "supportedLanguages": [],
    "links": [],
    "itemType": 0,
    "id": 224060,
    "success": 15,
    "visible": false,
    "name": "",
    "storeUrlPath": "app/0/",
    "appid": 0
}
```

And here's what a regular entry looks like:
```
{
    "includedTypes": [],
    "includedAppids": [],
    "contentDescriptorids": [],
    "tagids": [],
    "tags": [],
    "purchaseOptions": [],
    "accessories": [],
    "invalidPurchaseOptions": [],
    "supportedLanguages": [],
    "links": [],
    "itemType": 0,
    "id": 1260320,
    "success": 1,
    "visible": true,
    "name": "Party Animals",
    "storeUrlPath": "app/1260320/Party_Animals",
    "appid": 1260320,
    "type": 0,
    "categories": {
        "supportedPlayerCategoryids": [
            2,
            1,
            49,
            36,
            37,
            9,
            38,
            39,
            24,
            27
        ],
        "featureCategoryids": [
            22,
            35,
            44,
            62
        ],
        "controllerCategoryids": [
            28,
            55,
            56,
            57,
            58,
            60
        ]
    },
    "basicInfo": {
        "publishers": [
            {
                "name": "Source Technology"
            }
        ],
        "developers": [
            {
                "name": "Recreate Games"
            }
        ],
        "franchises": [],
        "shortDescription": "Fight your friends as puppies, kittens and other fuzzy creatures in PARTY ANIMALS! Paw it out with your friends remotely, or huddle together for chaotic fun on the same screen. Interact with the world under our realistic physics engine. Did I mention PUPPIES?"
    },
    "bestPurchaseOption": {
        "activeDiscounts": [],
        "packageid": 917099,
        "purchaseOptionName": "Party Animals",
        "finalPriceInCents": {
            "low": 7999,
            "high": 0,
            "unsigned": false
        },
        "formattedFinalPrice": "79,99 zł",
        "userCanPurchaseAsGift": true
    }
}
```